### PR TITLE
Remove RSP packaging, update jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ node('rhel7'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-8.11.1'
+		def nodeHome = tool 'nodejs-12.4.0'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 		sh "npm install -g typescript vsce"
 	}
@@ -30,7 +30,7 @@ node('rhel7'){
 	stage('Package') {
 		try {
 			def packageJson = readJSON file: 'package.json'
-			sh "vsce package -o adapters-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
+			sh "vsce package -o rsp-ui-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
 		}
 		finally {
 			archiveArtifacts artifacts: '*.vsix'
@@ -39,7 +39,7 @@ node('rhel7'){
 	if(params.UPLOAD_LOCATION) {
 		stage('Snapshot') {
 			def filesToPush = findFiles(glob: '**.vsix')
-			sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${filesToPush[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-middleware-tools/"
+			sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${filesToPush[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-middleware-tools/rsp-ui/"
 			stash name:'vsix', includes:filesToPush[0].path
 		}
 	}
@@ -58,10 +58,11 @@ node('rhel7'){
                 sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
             }
             archive includes:"**.vsix"
+		}
 
-            stage "Promote the build to stable"
+        stage("Promote the build to stable") {
             def vsix = findFiles(glob: '**.vsix')
-            sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-middleware-tools/"
+            sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-middleware-tools/rsp-ui/"
         }
 	}
 }

--- a/build/package.js
+++ b/build/package.js
@@ -1,7 +1,0 @@
-function clean() {
-    return Promise.resolve();
-}
-
-Promise.resolve()
-    .then(clean)
-    .catch((err)=>{ throw err; });

--- a/package.json
+++ b/package.json
@@ -282,7 +282,6 @@
     }
   },
   "scripts": {
-    "package": "node ./build/package.js",
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
@@ -290,7 +289,7 @@
     "test": "npm run compile && node ./node_modules/vscode/bin/test",
     "update-deps": "node_modules/.bin/ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
     "coverage:upload": "codecov -f coverage/coverage-final.json",
-    "build": "npm run compile && npm run package"
+    "build": "npm run compile"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",


### PR DESCRIPTION
AFAIK the RSP distros will now be packaged in the individual provider extensions, so removing it for some file size shedding. Also a small update to paths in jenkinsfile.