### PR TITLE
Differentiate start/stop commands clearly between RSP and Runtimes (#4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,37 +67,37 @@
       },
       {
         "command": "server.startRSP",
-        "title": "Start",
+        "title": "Start RSP Provider",
         "category": "Servers"
       },
       {
         "command": "server.stopRSP",
-        "title": "Stop",
+        "title": "Stop RSP Provider",
         "category": "Servers"
       },
       {
         "command": "server.terminateRSP",
-        "title": "Terminate",
+        "title": "Terminate RSP Provider",
         "category": "Servers"
       },
       {
         "command": "server.start",
-        "title": "Start",
+        "title": "Start Server",
         "category": "Servers"
       },
       {
         "command": "server.debug",
-        "title": "Debug",
+        "title": "Debug Server",
         "category": "Servers"
       },
       {
         "command": "server.stop",
-        "title": "Stop",
+        "title": "Stop Server",
         "category": "Servers"
       },
       {
         "command": "server.terminate",
-        "title": "Terminate",
+        "title": "Terminate Server",
         "category": "Servers"
       },
       {
@@ -112,7 +112,7 @@
       },
       {
         "command": "server.remove",
-        "title": "Remove",
+        "title": "Remove Server",
         "category": "Servers"
       },
       {


### PR DESCRIPTION
it fixes #4 

I'm very bad at naming so if you have any other good idea how to rename those commands to make them more clear, write it down :)