### PR TITLE
Update vscode requirement to match @types/vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "bugs": "https://github.com/redhat-developer/vscode-rsp-ui/issues/",
   "engines": {
-    "vscode": "^1.25.0"
+    "vscode": "^1.29.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
`vsce package` fails unless `@types/vscode` version is equal or smaller than required `vscode` version
fixing by bumping the required version (can be done the other way if desired though)