### PR TITLE
Add a Server treeview to Activity bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
       "view/title": [
         {
           "command": "server.createServer",
-          "when": "view == servers || view == serversAB",
+          "when": "view =~ '/(servers|serversAB)/'",
           "group": "navigation"
         }
       ],
@@ -209,102 +209,102 @@
       "view/item/context": [
         {
           "command": "server.startRSP",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPUnknown|RSPStopped)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(RSPUnknown|RSPStopped)/'",
           "group": "0_server-rspstartstop@1"
         },
         {
           "command": "server.stopRSP",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPStarted)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(RSPStarted)/'",
           "group": "0_server-rspstartstop@2"
         },
         {
           "command": "server.terminateRSP",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
+          "when": "view =~ (servers|serversAB) && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
           "group": "0_server-rspstartstop@2"
         },
         {
           "command": "server.createServer",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPStarted)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(RSPStarted)/'",
           "group": "0_server-rspstartstop@3"
         },
         {
           "command": "server.start",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^Stopped/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^Stopped/'",
           "group": "1_server-startstop@1"
         },
         {
           "command": "server.debug",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^Stopped/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^Stopped/'",
           "group": "1_server-startstop@2"
         },
         {
           "command": "server.stop",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(Started|Debugging)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(Started|Debugging)/'",
           "group": "1_server-startstop@3"
         },
         {
           "command": "server.restart",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(Started|Debugging)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(Started|Debugging)/'",
           "group": "1_server-startstop@4"
         },
         {
           "command": "server.restartDebug",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(Started|Debugging)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(Started|Debugging)/'",
           "group": "1_server-startstop@5"
         },
         {
           "command": "server.terminate",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Stopping)/",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Starting|Stopping)/",
           "group": "1_server-startstop@6"
         },
         {
           "command": "server.remove",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^Stopped/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^Stopped/'",
           "group": "2_server-remove@1"
         },
         {
           "command": "server.publishIncremental",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
           "group": "3_server-deployments@6"
         },
         {
           "command": "server.publishFull",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
           "group": "3_server-deployments@7"
         },
         {
           "command": "server.addDeployment",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|^Unknown)/",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|^Unknown)/",
           "group": "3_server-deployments@1"
         },
         {
           "command": "server.removeDeployment",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Synchronized|[+|-|Full]* Publish|Unknown)/",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Synchronized|[+|-|Full]* Publish|Unknown)/",
           "group": "3_server-deployments@2"
         },
         {
           "command": "server.output",
-          "when": "view == servers || view == serversAB && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'",
           "group": "4_server-status@1"
         },
         {
           "command": "server.downloadRuntime",
-          "when": "view == servers || view == serversAB && !viewItem",
+          "when": "view =~ '/(servers|serversAB)/' && !viewItem",
           "group": "5_rsp@1"
         },
         {
           "command": "server.addLocation",
-          "when": "view == servers || view == serversAB && !viewItem",
+          "when": "view =~ '/(servers|serversAB)/' && !viewItem",
           "group": "5_rsp@2"
         },
         {
           "command": "server.actions",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
           "group": "6_server-info@1"
         },
         {
           "command": "server.editServer",
-          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
           "group": "6_server-info@2"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onCommand:server.publishIncremental",
     "onCommand:server.actions",
     "onView:servers",
+    "onView:serversAB",
     "onLanguage:plaintext"
   ],
   "main": "./out/src/extension",
@@ -166,9 +167,10 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "serverView",
+          "id": "serverViewActivitybar",
           "title": "Server Connector",
-          "icon": "images/server-light.png"
+          "icon": "images/server-light.png",
+          "when": "false"
         }
       ]
     },
@@ -178,13 +180,19 @@
           "id": "servers",
           "name": "Servers"
         }
+      ],
+      "serverViewActivitybar": [
+        {
+          "id": "serversAB",
+          "name": "Servers"
+        }
       ]
     },
     "menus": {
       "view/title": [
         {
           "command": "server.createServer",
-          "when": "view == servers",
+          "when": "view == servers || view == serversAB",
           "group": "navigation"
         }
       ],
@@ -201,102 +209,102 @@
       "view/item/context": [
         {
           "command": "server.startRSP",
-          "when": "view == servers && viewItem =~ '/^(RSPUnknown|RSPStopped)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPUnknown|RSPStopped)/'",
           "group": "0_server-rspstartstop@1"
         },
         {
           "command": "server.stopRSP",
-          "when": "view == servers && viewItem =~ '/^(RSPStarted)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPStarted)/'",
           "group": "0_server-rspstartstop@2"
         },
         {
           "command": "server.terminateRSP",
-          "when": "view == servers && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
           "group": "0_server-rspstartstop@2"
         },
         {
           "command": "server.createServer",
-          "when": "view == servers && viewItem =~ '/^(RSPStarted)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(RSPStarted)/'",
           "group": "0_server-rspstartstop@3"
         },
         {
           "command": "server.start",
-          "when": "view == servers && viewItem =~ '/^Stopped/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^Stopped/'",
           "group": "1_server-startstop@1"
         },
         {
           "command": "server.debug",
-          "when": "view == servers && viewItem =~ '/^Stopped/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^Stopped/'",
           "group": "1_server-startstop@2"
         },
         {
           "command": "server.stop",
-          "when": "view == servers && viewItem =~ '/^(Started|Debugging)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(Started|Debugging)/'",
           "group": "1_server-startstop@3"
         },
         {
           "command": "server.restart",
-          "when": "view == servers && viewItem =~ '/^(Started|Debugging)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(Started|Debugging)/'",
           "group": "1_server-startstop@4"
         },
         {
           "command": "server.restartDebug",
-          "when": "view == servers && viewItem =~ '/^(Started|Debugging)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(Started|Debugging)/'",
           "group": "1_server-startstop@5"
         },
         {
           "command": "server.terminate",
-          "when": "view == servers && viewItem =~ /^(Starting|Stopping)/",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Stopping)/",
           "group": "1_server-startstop@6"
         },
         {
           "command": "server.remove",
-          "when": "view == servers && viewItem =~ '/^Stopped/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^Stopped/'",
           "group": "2_server-remove@1"
         },
         {
           "command": "server.publishIncremental",
-          "when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
           "group": "3_server-deployments@6"
         },
         {
           "command": "server.publishFull",
-          "when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
           "group": "3_server-deployments@7"
         },
         {
           "command": "server.addDeployment",
-          "when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|^Unknown)/",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|^Unknown)/",
           "group": "3_server-deployments@1"
         },
         {
           "command": "server.removeDeployment",
-          "when": "view == servers && viewItem =~ /^(Synchronized|[+|-|Full]* Publish|Unknown)/",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Synchronized|[+|-|Full]* Publish|Unknown)/",
           "group": "3_server-deployments@2"
         },
         {
           "command": "server.output",
-          "when": "view == servers && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'",
           "group": "4_server-status@1"
         },
         {
           "command": "server.downloadRuntime",
-          "when": "view == servers && !viewItem",
+          "when": "view == servers || view == serversAB && !viewItem",
           "group": "5_rsp@1"
         },
         {
           "command": "server.addLocation",
-          "when": "view == servers && !viewItem",
+          "when": "view == servers || view == serversAB && !viewItem",
           "group": "5_rsp@2"
         },
         {
           "command": "server.actions",
-          "when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
           "group": "6_server-info@1"
         },
         {
           "command": "server.editServer",
-          "when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
+          "when": "view == servers || view == serversAB && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'",
           "group": "6_server-info@2"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -163,8 +163,17 @@
         "category": "Application"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "serverView",
+          "title": "Server Connector",
+          "icon": "images/server-light.png"
+        }
+      ]
+    },
     "views": {
-      "explorer": [
+      "serverView": [
         {
           "id": "servers",
           "name": "Servers"

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
         },
         {
           "command": "server.terminateRSP",
-          "when": "view =~ (servers|serversAB) && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
+          "when": "view =~ '/(servers|serversAB)'/ && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
           "group": "0_server-rspstartstop@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
         },
         {
           "command": "server.terminateRSP",
-          "when": "view =~ '/(servers|serversAB)'/ && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
+          "when": "view =~ '/(servers|serversAB)/' && viewItem =~ '/^(RSPStarted|RSPStarting|RSPStopping)/'",
           "group": "0_server-rspstartstop@2"
         },
         {

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -76,11 +76,13 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
     private serverAttributes: Map<string, {required: Protocol.Attributes, optional: Protocol.Attributes}> =
         new Map<string, {required: Protocol.Attributes, optional: Protocol.Attributes}>();
     private readonly viewer: TreeView< RSPState | ServerStateNode | DeployableStateNode>;
+    private readonly viewerAB: TreeView< RSPState | ServerStateNode | DeployableStateNode>;
     public RSPServersStatus: Map<string, RSPProperties> = new Map<string, RSPProperties>();
     public serverSelected: ServerStateNode;
 
     private constructor() {
         this.viewer = window.createTreeView('servers', { treeDataProvider: this }) ;
+        this.viewerAB = window.createTreeView('serversAB', { treeDataProvider: this }) ;
 
         this.runStateEnum
             .set(0, 'Unknown')
@@ -214,6 +216,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
 
     public selectNode(data: RSPState | ServerStateNode): void {
         this.viewer.reveal(data, { focus: true, select: true });
+        this.viewerAB.reveal(data, { focus: true, select: true });
     }
 
     public async selectAndAddDeployment(state: ServerStateNode): Promise<Protocol.Status> {


### PR DESCRIPTION
it fixes #22 

@odockal @jeffmaury In this solution you'll find 2 server treeviews, one as it was before (in the explorer panel) and another (a clone) in the activity bar. You can start/stop/debug/execute any commands in one of them and you should see the treeview updated in the other view as well. 

I seriously don't see the advantages to have it in the activity bar because it's annoying to switch panel everytime (especially for moving from projects file to servers) but you can test it and see if it's better.

There is only one issue in this solution. The treeview only activate from the explorer panel. It means that if you first go in the server view from the activity bar you would not see any rsp-provider. Still don't know if it's a problem in my code or a limitation of vscode. Investigating on it. 