### PR TITLE
Improved tree refreshing

### DIFF
--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -104,7 +104,7 @@ export class CommandHandler {
 
             this.explorer.updateRSPServer(context.type.id, ServerState.STOPPED);
             this.explorer.disposeRSPProperties(context.type.id);
-            this.explorer.refresh();
+            this.explorer.refresh(context);
         } else {
             return Promise.reject(`The RSP server ${context.type.visibilename} is already stopped.`);
         }

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -583,7 +583,7 @@ export class CommandHandler {
     }
 
     public async saveSelectedNode(server: ServerStateNode): Promise<void> {
-        this.explorer.serverSelected = server;
+        this.explorer.nodeSelected = server;
     }
 
     private async selectRSP(message: string, predicateFilter?: (value: RSPProperties) => unknown): Promise<{ label: string; id: string; }> {
@@ -615,9 +615,12 @@ export class CommandHandler {
         if (!servers || servers.length < 1) {
             return Promise.reject('There are no servers to choose from.');
         }
-        if (servers.length > 1 && this.explorer.serverSelected && this.explorer.serverSelected.rsp === rspId) {
-            servers = servers.filter(node => node.server.id !== this.explorer.serverSelected.server.id);
-            servers.unshift(this.explorer.serverSelected);
+        if (servers.length > 1 &&
+            this.explorer.nodeSelected &&
+            'deployableStates' in this.explorer.nodeSelected &&
+            this.explorer.nodeSelected.rsp === rspId) {
+            servers = servers.filter(node => node.server.id !== (this.explorer.nodeSelected as ServerStateNode).server.id);
+            servers.unshift(this.explorer.nodeSelected);
         }
         return vscode.window.showQuickPick(servers.map(server => server.server.id), { placeHolder: message });
     }

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -102,9 +102,8 @@ export class CommandHandler {
                 });
             }
 
-            this.explorer.updateRSPServer(context.type.id, ServerState.STOPPED);
             this.explorer.disposeRSPProperties(context.type.id);
-            this.explorer.refresh(context);
+            this.explorer.updateRSPServer(context.type.id, ServerState.STOPPED);
         } else {
             return Promise.reject(`The RSP server ${context.type.visibilename} is already stopped.`);
         }

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -15,6 +15,7 @@ import {
     TreeItem,
     TreeItemCollapsibleState,
     TreeView,
+    TreeViewVisibilityChangeEvent,
     Uri,
     window,
     workspace
@@ -78,11 +79,13 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
     private readonly viewer: TreeView< RSPState | ServerStateNode | DeployableStateNode>;
     private readonly viewerAB: TreeView< RSPState | ServerStateNode | DeployableStateNode>;
     public RSPServersStatus: Map<string, RSPProperties> = new Map<string, RSPProperties>();
-    public serverSelected: ServerStateNode;
+    public nodeSelected: RSPState | ServerStateNode;
 
     private constructor() {
-        this.viewer = window.createTreeView('servers', { treeDataProvider: this }) ;
-        this.viewerAB = window.createTreeView('serversAB', { treeDataProvider: this }) ;
+        this.viewer = window.createTreeView('servers', { treeDataProvider: this });
+        this.viewerAB = window.createTreeView('serversAB', { treeDataProvider: this });
+        this.viewer.onDidChangeVisibility(this.changeViewer, this);
+        this.viewerAB.onDidChangeVisibility(this.changeViewer, this);
 
         this.runStateEnum
             .set(0, 'Unknown')
@@ -112,7 +115,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
         const client: RSPClient = this.getClientByRSP(rspId);
         if (client) {
             const servers: Protocol.ServerHandle[] = await client.getOutgoingHandler().getServerHandles();
-            await servers.forEach(async serverHandle => {
+            servers.forEach(async serverHandle => {
                 const state = await client.getOutgoingHandler().getServerState(serverHandle);
                 const serverNode: ServerStateNode = this.convertToServerStateNode(rspId, state);
                 this.RSPServersStatus.get(rspId).state.serverStates.push(serverNode);
@@ -129,22 +132,30 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             const serverNode: ServerStateNode = this.convertToServerStateNode(rspId, state);
             if (serverNode) {
                 this.RSPServersStatus.get(rspId).state.serverStates.push(serverNode);
-                this.refresh({rsp: rspId, ...state } as ServerStateNode);
+                this.refresh(this.RSPServersStatus.get(rspId).state);
+                this.selectNode({rsp: rspId, ...state } as ServerStateNode);
             }
         }
     }
 
     public updateRSPServer(rspId: string, state: number) {
         this.RSPServersStatus.get(rspId).state.state = state;
-        this.refresh();
+        this.refresh(this.RSPServersStatus.get(rspId).state);
     }
 
     public updateServer(rspId: string, event: Protocol.ServerState): void {
         const indexServer: number = this.RSPServersStatus.get(rspId).state.serverStates.
                                             findIndex(state => state.server.id === event.server.id);
-        const serverNode: ServerStateNode = this.convertToServerStateNode(rspId, event);
-        this.RSPServersStatus.get(rspId).state.serverStates[indexServer] = serverNode;
-        this.refresh();
+        const serverToUpdate: ServerStateNode = this.RSPServersStatus.get(rspId).state.serverStates[indexServer];
+        // update serverToUpdate based on event
+        Object.keys(event).forEach(key => {
+            if (key in serverToUpdate) {
+                serverToUpdate[key] = event[key];
+            }
+        });
+        serverToUpdate.deployableStates = this.convertToDeployableStateNodes(rspId, event.deployableStates);
+        this.RSPServersStatus.get(rspId).state.serverStates[indexServer] = serverToUpdate;
+        this.refresh(serverToUpdate);
         const channel: OutputChannel = this.serverOutputChannels.get(event.server.id);
         if (event.state === ServerState.STARTING && channel) {
             channel.clear();
@@ -179,7 +190,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
     public removeServer(rspId: string, handle: Protocol.ServerHandle): void {
         this.RSPServersStatus.get(rspId).state.serverStates = this.RSPServersStatus.get(rspId).state.serverStates.
                                                                         filter(state => state.server.id !== handle.id);
-        this.refresh();
+        this.refresh(this.RSPServersStatus.get(rspId).state);
         const channel: OutputChannel = this.serverOutputChannels.get(handle.id);
         this.serverOutputChannels.delete(handle.id);
         if (channel) {
@@ -208,15 +219,26 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
     }
 
     public refresh(data?: RSPState | ServerStateNode): void {
-        this._onDidChangeTreeData.fire();
+        this._onDidChangeTreeData.fire(data);
         if (data !== undefined && this.isServerElement(data)) {
             this.selectNode(data);
         }
     }
 
     public selectNode(data: RSPState | ServerStateNode): void {
-        this.viewer.reveal(data, { focus: true, select: true });
-        this.viewerAB.reveal(data, { focus: true, select: true });
+        this.nodeSelected = data;
+        const tmpViewer = this.viewerAB.visible ? this.viewerAB : this.viewer;
+        tmpViewer.reveal(data, { focus: true, select: true });
+    }
+
+    private changeViewer(_e: TreeViewVisibilityChangeEvent) {
+        if (!this.viewer.visible && !this.viewerAB.visible) {
+            return;
+        }
+        const tmpViewer = this.viewer.visible ? this.viewer : this.viewerAB;
+        if (this.nodeSelected) {
+            tmpViewer.reveal(this.nodeSelected, { focus: true, select: true });
+        }
     }
 
     public async selectAndAddDeployment(state: ServerStateNode): Promise<Protocol.Status> {
@@ -280,7 +302,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             return;
         }
         if (answer === 'Yes') {
-            const deployOptionsResponse: Protocol.ListDeploymentOptionsResponse = 
+            const deployOptionsResponse: Protocol.ListDeploymentOptionsResponse =
                 await client.getOutgoingHandler().listDeploymentOptions(state.server);
             const optionMap: Protocol.Attributes = deployOptionsResponse.attributes;
             for (const key in optionMap.attributes) {

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -476,16 +476,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             rspProps.rspserverstderr.dispose();
         }
 
-        const newProps = {
-            client: undefined,
-            rspserverstderr: undefined,
-            rspserverstdout: undefined,
-            state: {
-                ...rspProps.state,
-                serverStates: undefined
-            }
-        };
-        this.RSPServersStatus.set(rspId, newProps);
+        this.RSPServersStatus.get(rspId).state.serverStates = undefined;
     }
 
     /**

--- a/test/serverExplorer.test.ts
+++ b/test/serverExplorer.test.ts
@@ -274,11 +274,13 @@ suite('Server explorer', () => {
         };
 
         setup(() => {
-            findStatusStub = serverExplorer.RSPServersStatus.get('id').state.serverStates.findIndex = sandbox.stub();
+            serverExplorer.RSPServersStatus.get('id').state.serverStates = [ProtocolStubs.stoppedServerState];
+            findStatusStub = serverExplorer.RSPServersStatus.get('id').state.serverStates.findIndex = sandbox.stub().returns(0);
         });
 
         test('call should update server state to received in state change event (Stopped)', async () => {
             sandbox.stub(serverExplorer.runStateEnum, 'get').returns('Stopped');
+            sandbox.stub(serverExplorer, 'refresh');
             serverExplorer.selectNode = sandbox.stub();
             const children = serverExplorer.getChildren();
             const treeItem = await serverExplorer.getTreeItem(ProtocolStubs.unknownServerState);
@@ -294,6 +296,8 @@ suite('Server explorer', () => {
 
         test('call should update server state to received in state change event (Started)', async () => {
             sandbox.stub(serverExplorer.runStateEnum, 'get').returns('Started');
+            sandbox.stub(serverExplorer, 'refresh');
+            serverExplorer.selectNode = sandbox.stub();
             serverExplorer.selectNode = sandbox.stub();
             const children = serverExplorer.getChildren();
             const treeItem = await serverExplorer.getTreeItem(ProtocolStubs.unknownServerState);
@@ -320,6 +324,7 @@ suite('Server explorer', () => {
 
         test('call should update server state to received in state change event (Unknown)', async () => {
             sandbox.stub(serverExplorer.runStateEnum, 'get').returns('Unknown');
+            sandbox.stub(serverExplorer, 'refresh');
             serverExplorer.selectNode = sandbox.stub();
             const children = serverExplorer.getChildren();
             const treeItem = await serverExplorer.getTreeItem(ProtocolStubs.unknownServerState);

--- a/test/serverExplorer.test.ts
+++ b/test/serverExplorer.test.ts
@@ -859,21 +859,6 @@ suite('Server explorer', () => {
             serverExplorer.disposeRSPProperties('id');
             expect(disposeStdErrStub).calledOnce;
         });
-
-        test('check if new properties is set', async () => {
-            const newProps = {
-                client: undefined,
-                rspserverstderr: undefined,
-                rspserverstdout: undefined,
-                state: {
-                    ...serverExplorer.RSPServersStatus.get('id').state,
-                    serverStates: undefined
-                }
-            };
-            const setPropsStub = sandbox.stub(serverExplorer.RSPServersStatus, 'set');
-            serverExplorer.disposeRSPProperties('id');
-            expect(setPropsStub).calledOnceWith('id', newProps);
-        });
     });
 
     suite('updateRSPServer', () => {


### PR DESCRIPTION
it fixes #98 

Until now we refreshed all tree every time a new rsp/server was added/updated. I changed how the refresh works. Now it's launched on single nodes. 
There was also an issue related to the node selected when switching view, added a fix for that too.
@odockal Could you test this before merging? As it deals with the tree it is crucial that everything works. 
The only behavior which should be visible (performance should be almost the same, at least for me having only 1 rsp and 10 servers) is when someone stops a started rsp provider. Before, you could keep seeing the list of servers owning by that rsp. Now everything is cleaned up.