### PR TITLE
refactor editor window management during saving server properties (#101)

### DIFF
--- a/src/serverEditorAdapter.ts
+++ b/src/serverEditorAdapter.ts
@@ -126,7 +126,8 @@ export class ServerEditorAdapter {
                 return Promise.reject('Unable to save server properties - server is invalid');
             }
             return this.explorer.saveServerProperties(rspId, serverHandle, doc.getText()).then(updateStatus => {
-                this.createTmpFile(true, rspId, updateStatus.serverJson);
+                const file: string = this.RSPServerProperties.get(rspId).find(prop => prop.server === serverHandle.id).file;
+                this.saveAndShowEditor(file, updateStatus.serverJson.serverJson);
                 vscode.window.showInformationMessage(`Server ${serverHandle.id} correctly saved`);
                 return updateStatus.validation.status;
             });

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -280,7 +280,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             return;
         }
         if (answer === 'Yes') {
-            const deployOptionsResponse: Protocol.ListDeploymentOptionsResponse = 
+            const deployOptionsResponse: Protocol.ListDeploymentOptionsResponse =
                 await client.getOutgoingHandler().listDeploymentOptions(state.server);
             const optionMap: Protocol.Attributes = deployOptionsResponse.attributes;
             for (const key in optionMap.attributes) {

--- a/test/serverEditorAdapter.test.ts
+++ b/test/serverEditorAdapter.test.ts
@@ -367,7 +367,7 @@ suite('ServerEditorAdapter', () => {
             };
             serverEditorAdapter.RSPServerProperties.set('id', [serverProps]);
             sandbox.stub(serverExplorer, 'getServerStateById').returns(ProtocolStubs.unknownServerState);
-            sandbox.stub(serverEditorAdapter, 'createTmpFile' as any).callsFake(() => '');
+            sandbox.stub(serverEditorAdapter, 'saveAndShowEditor' as any).callsFake(() => '');
 
             await serverEditorAdapter.onDidSaveTextDocument(textDocumentWithUri);
             expect(saveStub).calledOnceWith('id', ProtocolStubs.serverHandle, '');
@@ -382,7 +382,7 @@ suite('ServerEditorAdapter', () => {
             };
             serverEditorAdapter.RSPServerProperties.set('id', [serverProps]);
             sandbox.stub(serverExplorer, 'getServerStateById').returns(ProtocolStubs.unknownServerState);
-            sandbox.stub(serverEditorAdapter, 'createTmpFile' as any).callsFake(() => '');
+            sandbox.stub(serverEditorAdapter, 'saveAndShowEditor' as any).callsFake(() => '');
 
             await serverEditorAdapter.onDidSaveTextDocument(textDocumentWithUri);
             expect(showInfoStub).calledOnceWith('Server id correctly saved');


### PR DESCRIPTION
it improves the UI based on #101 
It prevents a new editor window to be created when server properties are saved.