### PR TITLE
Adding ui-tests for remote server protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 server
 coverage/
 felix-cache/
+test-resources/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,10 @@ node_js:
 matrix:
   include:
     - os: linux
-      dist: trusty
     - os: osx
 
-before_install:
-- if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
-- npm install -g typescript
+services:
+- xvfb
 
 install:
 - npm install
@@ -24,4 +18,5 @@ install:
 
 script:
 - npm test --silent
+- npm run ui-test
 - npm run coverage:upload

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 out/test/**
 out/**/*.map
 src/**
+test-resources/
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
-		git url: 'https://github.com/redhat-developer/vscode-rsp-ui.git'
+		git url: "https://github.com/${params.FORK}/vscode-rsp-ui.git", branch: params.BRANCH
 	}
 
 	stage('Install requirements') {
@@ -21,6 +21,7 @@ node('rhel7'){
 		stage('Test') {
 			wrap([$class: 'Xvnc']) {
 				sh "npm test --silent"
+				sh "npm run ui-test"
 				//cobertura coberturaReportFile: 'coverage/cobertura-coverage.xml'
 				junit 'report.xml'
 			}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "bugs": "https://github.com/redhat-developer/vscode-rsp-ui/issues/",
   "engines": {
-    "vscode": "^1.30.0"
+    "vscode": "^1.34.0"
   },
   "categories": [
     "Other"
@@ -373,6 +373,7 @@
     "watch": "tsc -watch -p ./",
     "clean": "rm -rf out || rmdir out /s /q",
     "test": "npm run clean && npm run compile && node ./out/test/unit-tests.js",
+    "ui-test": "npm run compile && extest setup-and-run out/src/ui-test/allTestsSuite.js",
     "update-deps": "node_modules/.bin/ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
     "coverage:upload": "codecov -f coverage/coverage-final.json",
     "build": "npm run compile"
@@ -394,9 +395,10 @@
     "remap-istanbul": "^0.13.0",
     "sinon": "^6.3.4",
     "sinon-chai": "^3.2.0",
-    "tslint": "^5.16.0",
+    "tslint": "^5.17.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^3.4.5",
+    "typescript": "^3.5.2",
+    "vscode-extension-tester": "^2.5.0",
     "vscode-test": "^1.2.3"
   },
   "dependencies": {

--- a/src/ui-test/allTestsSuite.ts
+++ b/src/ui-test/allTestsSuite.ts
@@ -1,0 +1,8 @@
+import { extensionUIAssetsTest } from './extensionUITest';
+
+/**
+ * @author Ondrej Dockal <odockal@redhat.com>
+ */
+describe('VSCode RSP UI - UI tests', () => {
+    extensionUIAssetsTest();
+});

--- a/src/ui-test/common/adaptersContants.ts
+++ b/src/ui-test/common/adaptersContants.ts
@@ -1,0 +1,35 @@
+/**
+ * @author Ondrej Dockal <odockal@redhat.com>
+ */
+export class AdaptersConstants {
+
+    public static readonly RSP_UI_NAME = 'Remote Server Protocol UI';
+    public static readonly RSP_CONNECTOR_NAME = 'Server Connector';
+    public static readonly RSP_COMMAND = 'Servers:';
+    public static readonly RSP_SERVERS_LABEL = 'Servers';
+    public static readonly RSP_ATIVITY_BAR_TITLE = 'SERVER CONNECTOR: SERVERS';
+    public static readonly RSP_SERVER_ACTION_BUTTON = 'Create New Server...';
+
+    public static readonly RSP_MAIN_COMMANDS = [
+        "Create New Server...",
+        "Add Local Server...",
+        "Download Server...",
+        "Start RSP Provider",
+        "Stop RSP Provider",
+        "Terminate RSP Provider",
+        "Start Server",
+        "Debug Server",
+        "Stop Server",
+        "Terminate Server",
+        "Restart in Run Mode",
+        "Restart in Debug Mode",
+        "Remove Server",
+        "Show Output Channel",
+        "Add Deployment",
+        "Remove Deployment",
+        "Publish Server (Incremental)",
+        "Publish Server (Full)",
+        "Server Actions...",
+        "Edit Server",
+    ];
+}

--- a/src/ui-test/extensionUITest.ts
+++ b/src/ui-test/extensionUITest.ts
@@ -1,0 +1,101 @@
+import { AdaptersConstants } from './common/adaptersContants';
+import { expect } from 'chai';
+import { ActivityBar, SideBarView, ViewControl, Workbench, QuickOpenBox, ExtensionsViewSection, ExtensionsViewItem } from 'vscode-extension-tester';
+
+/**
+ * @author Ondrej Dockal <odockal@redhat.com>
+ */
+export function extensionUIAssetsTest() {
+    describe('Verify extension\'s base assets are available after installation', () => {
+
+        let view: ViewControl;
+        let sideBar: SideBarView;
+        let quickBox: QuickOpenBox;
+
+        before(async function() {
+            this.timeout(4000);
+            view = new ActivityBar().getViewControl('Extensions');
+            sideBar = await view.openView();
+            quickBox = await new Workbench().openCommandPrompt();
+        });
+
+        it('Command Palette prompt knows RSP commands', async function() {
+            this.timeout(30000);
+            await verifyCommandPalette(quickBox);
+        });
+
+        it('Remote Server Protocol UI extension is installed', async function() {
+            this.timeout(5000);
+            const section = await sideBar.getContent().getSection('Enabled') as ExtensionsViewSection;
+            const item = await section.findItem(`@installed ${AdaptersConstants.RSP_UI_NAME}`) as ExtensionsViewItem;
+            expect(item).not.undefined;
+        });
+
+        it('Servers activity bar is available', async function() {
+            this.timeout(5000);
+            const viewControls = await new ActivityBar().getViewControls();
+            expect(viewControls.map(item => item.getTitle())).to.include(AdaptersConstants.RSP_CONNECTOR_NAME);
+            const serversView = new ActivityBar().getViewControl(AdaptersConstants.RSP_CONNECTOR_NAME);
+            expect(serversView).not.undefined;
+            const serversBar = await serversView.openView();
+            expect(serversBar).not.undefined;
+            expect(await serversBar.getTitlePart().getTitle()).to.equal(AdaptersConstants.RSP_ATIVITY_BAR_TITLE);
+        });
+
+        it('Action button from Servers activity bar is available', async function() {
+            this.timeout(5000);
+            const serversView = new ActivityBar().getViewControl(AdaptersConstants.RSP_CONNECTOR_NAME);
+            const serversBar = await serversView.openView();
+            const titlePart = serversBar.getTitlePart();
+            const actionsButton = await titlePart.getActions();
+            expect(actionsButton.length).to.equal(1);
+            expect(actionsButton[0].getTitle()).to.include('Create New Server');
+        });
+
+        it('Servers tab is available under Explorer bar', async function() {
+            this.timeout(5000);
+            const explorerView = new ActivityBar().getViewControl('Explorer');
+            expect(explorerView).not.undefined;
+            const bar = await explorerView.openView();
+            const content = bar.getContent();
+            const sections = await content.getSections();
+            expect(await Promise.all(sections.map(item => item.getTitle()))).to.include(AdaptersConstants.RSP_SERVERS_LABEL);
+            const section = await content.getSection(AdaptersConstants.RSP_SERVERS_LABEL);
+            expect(section).not.undefined;
+            expect(await section.getTitle()).to.equal(AdaptersConstants.RSP_SERVERS_LABEL);
+            const actionsButton = await section.getActions();
+            expect(actionsButton.length).to.equal(1);
+            expect(actionsButton[0].getLabel()).to.equal(AdaptersConstants.RSP_SERVER_ACTION_BUTTON);
+        });
+
+        after(async function() {
+            this.timeout(4000);
+            if (sideBar && await sideBar.isDisplayed()) {
+                sideBar = await new ActivityBar().getViewControl('Extensions').openView();
+                const actionButton = await sideBar.getTitlePart().getAction('Clear Extensions Input');
+                await actionButton.click();
+                view.closeView();
+            }
+            if (quickBox && await quickBox.isDisplayed()) {
+                await quickBox.cancel();
+            }
+        });
+    });
+}
+
+async function verifyCommandPalette(quick: QuickOpenBox) {
+    if (!quick || ! await quick.isDisplayed()) {
+        quick = await new Workbench().openCommandPrompt();
+    }
+    await quick.setText(`>${AdaptersConstants.RSP_COMMAND}`);
+    const options = await quick.getQuickPicks();
+    expect(await options[0].getText()).not.equal('No commands matching');
+    expect(await options[0].getText()).not.equal('No results found');
+    for (const element of AdaptersConstants.RSP_MAIN_COMMANDS) {
+        const expression = AdaptersConstants.RSP_COMMAND + ' ' + element;
+        await quick.setText(`>${expression}`);
+        const option = await quick.getQuickPicks();
+        const optionsString = await Promise.all(option.map(item => item.getText()));
+        expect(optionsString).to.have.members([expression]);
+    };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "exclude": [
         "node_modules",
-        ".vscode-test"
+        ".vscode-test",
+        "test-resources"
     ]
 }


### PR DESCRIPTION
   - add vscode-extension-tester dependency
   - add 'ui-test' script command to run ui tests
   - add basic extension UI test cases

Signed-off-by: Ondrej Dockal <odockal@redhat.com>