### PR TITLE
added id to tree nodes (#106)

### DIFF
--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -577,6 +577,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             const depStr = `${id1} (${serverState})`;
             const icon = await Utils.getIcon(state.type.id, state.type.id);
             return { label: `${depStr}`,
+                id: id1,
                 iconPath: icon,
                 contextValue: `RSP${serverState}`,
                 collapsibleState: TreeItemCollapsibleState.Expanded
@@ -593,6 +594,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             const depStr = `${id1} (${serverState}) (${pubState})`;
             const icon = await Utils.getIcon(state.rsp, handle.type.id);
             return { label: `${depStr}`,
+                id: `${state.rsp}-${id1}`,
                 iconPath: icon,
                 contextValue: serverState,
                 collapsibleState: TreeItemCollapsibleState.Expanded,

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -149,7 +149,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
         const serverToUpdate: ServerStateNode = this.RSPServersStatus.get(rspId).state.serverStates[indexServer];
         // update serverToUpdate based on event
         Object.keys(event).forEach(key => {
-            if (key in serverToUpdate) {
+            if (key in serverToUpdate || key === 'runMode') {
                 serverToUpdate[key] = event[key];
             }
         });


### PR DESCRIPTION
possible fix for #106 

@odockal i was not able to replicate the issue so i'm not sure this could solve that. Give it a try please.

Because if you don't define any id value, they will be dinamically created by using nodes labels i've tried to create them statically. Now the id of a rsp node is its **name** and the id of a server node is **rspName-serverName**. 

Hopefully we should not face any error like `Cannot resolve tree item for element 0/0:Red Hat Server Connector (Started)/0:wildfly-18 (Stopped) (Unknown)` anymore. 

The second option is to move the rsp/server state (Starter/Stopped/...) in the description of the node and keep the name as label so the id created should be the same. But this will cause a little change in the ui (the description is displayed in grey and with a smaller font).