### PR TITLE
Add check for RSPProperties.info when undefined in getTreeItem, fixes #124

### DIFF
--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -573,7 +573,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
             const id1: string = state.type.visibilename;
             // TODO fix the run state here, but need to find the RSPProperties for this RSPState
             const props: RSPProperties = this.RSPServersStatus.get(state.type.id);
-            const useConnected = (state.state == 2 && props.info.spawned == false);
+            const useConnected = (state.state == 2 && (props.info ? props.info.spawned : null) == false);
             const serverState = useConnected ? `Connected` : `${this.runStateEnum.get(state.state)}`;
             const icon = await Utils.getIcon(state.type.id, state.type.id);
             return { label: `${id1}`,

--- a/src/ui-test/extensionUITest.ts
+++ b/src/ui-test/extensionUITest.ts
@@ -31,25 +31,14 @@ export function extensionUIAssetsTest() {
             expect(item).not.undefined;
         });
 
-        it('Servers activity bar is available', async function() {
+        it('Action button "Create New Server..." from Servers tab is available', async function() {
             this.timeout(5000);
-            const viewControls = await new ActivityBar().getViewControls();
-            expect(viewControls.map(item => item.getTitle())).to.include(AdaptersConstants.RSP_CONNECTOR_NAME);
-            const serversView = new ActivityBar().getViewControl(AdaptersConstants.RSP_CONNECTOR_NAME);
-            expect(serversView).not.undefined;
-            const serversBar = await serversView.openView();
-            expect(serversBar).not.undefined;
-            expect(await serversBar.getTitlePart().getTitle()).to.equal(AdaptersConstants.RSP_ATIVITY_BAR_TITLE);
-        });
-
-        it('Action button from Servers activity bar is available', async function() {
-            this.timeout(5000);
-            const serversView = new ActivityBar().getViewControl(AdaptersConstants.RSP_CONNECTOR_NAME);
-            const serversBar = await serversView.openView();
-            const titlePart = serversBar.getTitlePart();
-            const actionsButton = await titlePart.getActions();
-            expect(actionsButton.length).to.equal(1);
-            expect(actionsButton[0].getTitle()).to.include('Create New Server');
+            const explorerView = new ActivityBar().getViewControl('Explorer');
+            const bar = await explorerView.openView();
+            const content = bar.getContent();
+            const section = await content.getSection(AdaptersConstants.RSP_SERVERS_LABEL);
+            const actionButton = section.getAction(AdaptersConstants.RSP_SERVER_ACTION_BUTTON);
+            expect(actionButton.getLabel()).to.equal(AdaptersConstants.RSP_SERVER_ACTION_BUTTON)
         });
 
         it('Servers tab is available under Explorer bar', async function() {
@@ -60,7 +49,7 @@ export function extensionUIAssetsTest() {
             const content = bar.getContent();
             const sections = await content.getSections();
             expect(await Promise.all(sections.map(item => item.getTitle()))).to.include(AdaptersConstants.RSP_SERVERS_LABEL);
-            const section = await content.getSection(AdaptersConstants.RSP_SERVERS_LABEL);
+            const section = await content.getSection(AdaptersConstants.RSP_SERVERS_LABEL); 
             expect(section).not.undefined;
             expect(await section.getTitle()).to.equal(AdaptersConstants.RSP_SERVERS_LABEL);
             const actionsButton = await section.getActions();


### PR DESCRIPTION
This might fix issue #124. But at first I would like to have you reproduced the issue or take a look, please. Thanks.