### PR TITLE
Fixes #131 - open add-deployment file picker in workspace

### DIFF
--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -284,12 +284,19 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
         // Windows -> if both options (canSelectFiles and canSelectFolders) are true, fs only shows folders
         // Linux(fedora) -> if both options are true, fs shows both files and folders but files are unselectable
         // Mac OS -> if both options are true, it works correctly
-        var d = workspace.workspaceFile != undefined ? workspace.workspaceFile : 
-                workspace.workspaceFolders == undefined ? undefined : 
-                workspace.workspaceFolders.length <= 0 ? undefined : 
-                workspace.workspaceFolders[0].uri;
+
+        const activeEditorUri = window.activeTextEditor === undefined ? undefined : 
+                            window.activeTextEditor.document === undefined ? undefined : 
+                            window.activeTextEditor.document.uri;
+        const workspaceFolderUri =  (workspace.workspaceFolders !== undefined && workspace.workspaceFolders.length > 0) 
+                                    ? workspace.workspaceFolders[0].uri : undefined;
+        const workspaceFileUri = workspace.workspaceFile === undefined ? undefined :
+                                    workspace.workspaceFile.scheme === "file" ? workspace.workspaceFile : undefined;
+        const uriToOpen = activeEditorUri !== undefined ? activeEditorUri :
+                        workspaceFolderUri !== undefined ? workspaceFolderUri : 
+                        workspaceFileUri;
         return {
-            defaultUri: d,
+            defaultUri: uriToOpen,
             canSelectFiles: (showQuickPick ? filePickerType === deploymentStatus.file : true),
             canSelectMany: false,
             canSelectFolders: (showQuickPick ? filePickerType === deploymentStatus.exploded : true),

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -284,7 +284,12 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
         // Windows -> if both options (canSelectFiles and canSelectFolders) are true, fs only shows folders
         // Linux(fedora) -> if both options are true, fs shows both files and folders but files are unselectable
         // Mac OS -> if both options are true, it works correctly
+        var d = workspace.workspaceFile != undefined ? workspace.workspaceFile : 
+                workspace.workspaceFolders == undefined ? undefined : 
+                workspace.workspaceFolders.length <= 0 ? undefined : 
+                workspace.workspaceFolders[0].uri;
         return {
+            defaultUri: d,
             canSelectFiles: (showQuickPick ? filePickerType === deploymentStatus.file : true),
             canSelectMany: false,
             canSelectFolders: (showQuickPick ? filePickerType === deploymentStatus.exploded : true),

--- a/test/serverExplorer.test.ts
+++ b/test/serverExplorer.test.ts
@@ -538,6 +538,7 @@ suite('Server explorer', () => {
             await serverExplorer.selectAndAddDeployment(ProtocolStubs.startedServerState);
 
             const filePickerResult = stubDialog.getCall(0).args[0];
+            filePickerResult.defaultUri = undefined;
             expect(JSON.stringify(filePickerResult)).equals(JSON.stringify(filePickerResponseWindows));
         });
 
@@ -557,6 +558,7 @@ suite('Server explorer', () => {
             await serverExplorer.selectAndAddDeployment(ProtocolStubs.startedServerState);
 
             const folderPickerResult = stubDialog.getCall(0).args[0];
+            folderPickerResult.defaultUri = undefined;
             expect(JSON.stringify(folderPickerResult)).equals(JSON.stringify(folderPickerResponseWindows));
         });
 
@@ -576,6 +578,7 @@ suite('Server explorer', () => {
             await serverExplorer.selectAndAddDeployment(ProtocolStubs.startedServerState);
 
             const filePickerResult = stubDialog.getCall(0).args[0];
+            filePickerResult.defaultUri = undefined;
             expect(JSON.stringify(filePickerResult)).equals(JSON.stringify(filePickerResponseLinux));
         });
 
@@ -595,6 +598,7 @@ suite('Server explorer', () => {
             await serverExplorer.selectAndAddDeployment(ProtocolStubs.startedServerState);
 
             const folderPickerResult = stubDialog.getCall(0).args[0];
+            folderPickerResult.defaultUri = undefined;
             expect(JSON.stringify(folderPickerResult)).equals(JSON.stringify(folderPickerResponseLinux));
         });
 
@@ -614,6 +618,7 @@ suite('Server explorer', () => {
             await serverExplorer.selectAndAddDeployment(ProtocolStubs.startedServerState);
 
             const pickerResult = stubDialog.getCall(0).args[0];
+            pickerResult.defaultUri = undefined;
             expect(JSON.stringify(pickerResult)).equals(JSON.stringify(pickerResponseDialog));
         });
 


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>