### PR TITLE
Prevent the output panel to steal focus

### DIFF
--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -209,14 +209,14 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
         }
         channel.append(output.text);
         if (workspace.getConfiguration('vscodeAdapters').get<boolean>('showChannelOnServerOutput')) {
-            channel.show();
+            channel.show(true);
         }
     }
 
     public showOutput(state: ServerStateNode): void {
         const channel: OutputChannel = this.serverOutputChannels.get(state.server.id);
         if (channel && workspace.getConfiguration('vscodeAdapters').get<boolean>('showChannelOnServerOutput')) {
-            channel.show();
+            channel.show(true);
         }
     }
 


### PR DESCRIPTION
Prevents the output panel to steal focus when `showChannelOnServerOutput` is true, this actually solves #156 .