### PR TITLE
Update to vscode-redhat-telemetry 0.2.0

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -1,6 +1,8 @@
-## [RSP UI by Red Hat](https://github.com/redhat-developer/vscode-rsp-ui)
+# Data collection
 
-### Usage Data
+[RSP UI by Red Hat](https://github.com/redhat-developer/vscode-rsp-ui) has opt-in telemetry collection, provided by [vscode-redhat-telemetry](https://github.com/redhat-developer/vscode-redhat-telemetry).
+
+## What's included in the RSP UI telemetry data
 
 * when extension is activated
 * when a command contributed by extension is executed
@@ -9,4 +11,14 @@
     * command's error message (in case of exception)
     * command's specific data (see details below)
 * when extension is deactivated
+
+## What's included in the general telemetry data
+
+Please see the
+[vscode-redhat-telemetry data collection information](https://github.com/redhat-developer/vscode-redhat-telemetry/blob/HEAD/USAGE_DATA.md#usage-data-being-collected-by-red-hat-extensions)
+for information on what data it collects.
+
+## How to opt in or out
+
+Use the `redhat.telemetry.enabled` setting in order to enable or disable telemetry collection.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@redhat-developer/vscode-redhat-telemetry": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.1.1.tgz",
-      "integrity": "sha512-uMJNiFNUXCYy/4KZaX+Ctueq+KXIWyS5Cfv2wqHNNzpV9+EhPLHUJoZKbCMY/P+IlgqTWYfpDkghZHiq5ChvEA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.2.0.tgz",
+      "integrity": "sha512-qS9p+iXpdMwCzhVRr/Ft5dMQQXB+6CxBRnpp3NDUuxYP1s/K/B1dPlIW5lKncjPUwYaKvPbpMgGGDmsosOzT8A==",
       "requires": {
         "@types/analytics-node": "^3.1.4",
         "analytics-node": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -408,7 +408,7 @@
     "vscode-test": "^1.5.2"
   },
   "dependencies": {
-    "@redhat-developer/vscode-redhat-telemetry": "0.1.1",
+    "@redhat-developer/vscode-redhat-telemetry": "0.2.0",
     "@redhat-developer/vscode-wizard": "^0.2.4",
     "path": "0.12.7",
     "rsp-client": "^0.23.1",

--- a/path
+++ b/path
@@ -1,0 +1,1 @@
+content

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,13 +11,14 @@ import { ServerEditorAdapter } from './serverEditorAdapter';
 import { ServerExplorer } from './serverExplorer';
 import * as vscode from 'vscode';
 import { RSPModel } from 'vscode-server-connector-api';
-import sendTelemetry from './telemetry';
+import { initializeTelemetry, sendTelemetry}  from './telemetry';
 
 let serversExplorer: ServerExplorer;
 let commandHandler: CommandHandler;
 export let myContext: vscode.ExtensionContext;
 
 export async function activate(context: vscode.ExtensionContext): Promise<RSPModel> {
+    initializeTelemetry(context);
     serversExplorer = ServerExplorer.getInstance();
     commandHandler = new CommandHandler(serversExplorer);
     myContext = context;
@@ -99,7 +100,6 @@ export function deactivate() {
             }
         }
     }
-    sendTelemetry('deactivation');
 }
 
 function onDidSaveTextDocument(doc: vscode.TextDocument) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,15 +18,15 @@ let commandHandler: CommandHandler;
 export let myContext: vscode.ExtensionContext;
 
 export async function activate(context: vscode.ExtensionContext): Promise<RSPModel> {
-    initializeTelemetry(context);
+    await initializeTelemetry(context);
     serversExplorer = ServerExplorer.getInstance();
     commandHandler = new CommandHandler(serversExplorer);
     myContext = context;
-    registerCommands(commandHandler, context);
+    await registerCommands(commandHandler, context);
     return getAPI();
 }
 
-function registerCommands(commandHandler: CommandHandler, context: vscode.ExtensionContext) {
+async function registerCommands(commandHandler: CommandHandler, context: vscode.ExtensionContext) {
     const newLocal = [
         vscode.commands.registerCommand('server.startRSP', context => executeCommand(
             commandHandler.startRSP, commandHandler, context, 'Unable to start the server: ')),
@@ -85,9 +85,7 @@ function registerCommands(commandHandler: CommandHandler, context: vscode.Extens
     const subscriptions = newLocal;
     subscriptions.forEach(element => {  context.subscriptions.push(element); }, this);
 
-    sendTelemetry('activation').catch(err => {
-        vscode.window.showErrorMessage(err);
-    });
+    return sendTelemetry('activation');
 }
 
 export function deactivate() {

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -15,7 +15,7 @@ import { Utils } from './utils/utils';
 import * as vscode from 'vscode';
 import { RSPController, ServerInfo } from 'vscode-server-connector-api';
 import { WorkflowResponseStrategy, WorkflowResponseStrategyManager } from './workflow/response/workflowResponseStrategyManager';
-import sendTelemetry from './telemetry';
+import { sendTelemetry } from './telemetry';
 
 export interface ServerActionItem {
     label: string;

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -31,7 +31,7 @@ import {
 import { ServerEditorAdapter } from './serverEditorAdapter';
 import { Utils } from './utils/utils';
 import { RSPType, ServerInfo } from 'vscode-server-connector-api';
-import sendTelemetry from './telemetry';
+import { sendTelemetry } from './telemetry';
 import { IWizardPage, Template, WebviewWizard, WizardDefinition,WizardPageFieldDefinition, WizardPageSectionDefinition } from '@redhat-developer/vscode-wizard';
 import { PerformFinishResponse } from '@redhat-developer/vscode-wizard/lib/IWizardWorkflowManager';
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -32,7 +32,8 @@ export function createTrackingEvent(name: string, properties: any = {}): Telemet
 export async function sendTelemetry(actionName: string, properties?: any): Promise<void> {
     const service = await getTelemetryServiceInstance();
     if (actionName === 'activation') {
-        return service?.sendStartupEvent();
+        await service?.sendStartupEvent();
+    } else {
+        await service?.send(createTrackingEvent(actionName, properties));
     }
-    return service?.send(createTrackingEvent(actionName, properties));
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,9 +8,14 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-import { getTelemetryService, TelemetryEvent, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry';
+import { getRedHatService, TelemetryEvent, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry';
+import { ExtensionContext } from 'vscode';
 
-const telemetryService: Promise<TelemetryService> = getTelemetryService("redhat.vscode-rsp-ui");
+let telemetryService: Promise<TelemetryService>;
+
+export async function initializeTelemetry(context:ExtensionContext) {
+    telemetryService = (await getRedHatService(context)).getTelemetryService();
+}
 
 export async function getTelemetryServiceInstance(): Promise<TelemetryService> {
     return telemetryService;
@@ -24,7 +29,7 @@ export function createTrackingEvent(name: string, properties: any = {}): Telemet
     }
 }
 
-export default async function sendTelemetry(actionName: string, properties?: any): Promise<void> {
+export async function sendTelemetry(actionName: string, properties?: any): Promise<void> {
     const service = await getTelemetryServiceInstance();
     if (actionName === 'activation') {
         return service?.sendStartupEvent();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -37,8 +37,13 @@ suite('Extension Tests', () => {
         }
     }
 
+    let extensionPath = process.cwd();
+    const testFolder = extensionPath.indexOf('.vscode-test');
+    if (testFolder > -1) {// when running on windows, need to find proper location
+        extensionPath = extensionPath.substring(0, testFolder);
+    }
     const context: vscode.ExtensionContext = {
-        extensionPath: 'path',
+        extensionPath: extensionPath,
         storagePath: 'string',
         subscriptions: [],
         workspaceState: new DummyMemento(),


### PR DESCRIPTION
Fixes #186 to really really drop vscode-commons.

Also fixes some issues when running in vscode < 1.55 (see https://github.com/redhat-developer/vscode-xml/pull/520)


