### PR TITLE
Keep focus on editor when displaying logs

### DIFF
--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -837,7 +837,7 @@ export class CommandHandler {
 
     private displayLog(outputPanel: vscode.OutputChannel, message: string, show = true) {
         if (outputPanel) {
-            if (show) outputPanel.show();
+            if (show) outputPanel.show(true);
             outputPanel.appendLine(message);
         }
     }


### PR DESCRIPTION
When extension is logging, output window is grabbing focus and this is extremely frustrating.

Used `preserveFocus` property from the `OutputChannel` `show` method: 
https://code.visualstudio.com/api/references/vscode-api#OutputChannel 