### PR TITLE
The deprecated "java.home" configuration tag has been replaced.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This extension supports a number of commands for interacting with supported serv
    This extension contributes the following settings:
 
    * `vscodeAdapters.showChannelOnServerOutput`: enable/disable the server output channel logs
-   * `java.home`: Specifies the path to a JDK (version 8 or newer) which will be used to launch the Runtime Server Protocol (RSP) Server, as well as be the default java to launch any Java-based runtimes that the RSP will control.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"
+   * `java.jdt.ls.java.home`: Specifies the path to a JDK (version 8 or newer) which will be used to launch the Runtime Server Protocol (RSP) Server, as well as be the default java to launch any Java-based runtimes that the RSP will control.\nOn Windows, backslashes must be escaped, i.e.\n\"java.jdt.ls.java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"
    * `rsp-ui.enableStartServerOnActivation`: Specifies which RSP Server have to be automatically started during activation. If option is disabled, user will have to manually start the RSP Server through command palette or context menu
    * `rsp-ui.enableAsyncPublish`: enable/disable async publishing
 
@@ -60,7 +60,7 @@ This extension supports a number of commands for interacting with supported serv
    * `"deployables"` - the list of deployables. It contains all informations related to each deployable.
    * `"server.autopublish.enabled"` - Enable the autopublisher
    * `"server.autopublish.inactivity.limit"` - Set the inactivity limit before the autopublisher runs
-   * `"vm.install.path"` - A string representation pointing to a java home. If not set, java.home will be used instead
+   * `"vm.install.path"` - A string representation pointing to a java home. If not set, java.jdt.ls.java.home will be used instead
 
 ### Provisional Global Server Parameters
    These settings may eventually be supported by all servers, but these settings are Provisional and may be changed before becoming official API. 

--- a/package.json
+++ b/package.json
@@ -317,13 +317,13 @@
       "type": "object",
       "title": "Servers View",
       "properties": {
-        "java.home": {
+        "java.jdt.ls.java.home": {
           "type": [
             "string",
             "null"
           ],
           "default": null,
-          "description": "Specifies the path to a JDK (version 8 or newer) which will be used to launch the Runtime Server Protocol (RSP) Server, as well as be the default java to launch any Java-based runtimes that the RSP will control.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"",
+          "description": "Specifies the path to a JDK (version 8 or newer) which will be used to launch the Runtime Server Protocol (RSP) Server, as well as be the default java to launch any Java-based runtimes that the RSP will control.\nOn Windows, backslashes must be escaped, i.e.\n\"java.jdt.ls.java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"",
           "scope": "window"
         },
         "redhat.telemetry.enabled": {


### PR DESCRIPTION
The deprecated _**"java.home"**_ configuration tag has been replaced by _**"java.jdt.ls.java.home"**_.

This configuration tag is already deprecated in current versions of vscode with the proper java extensions installed, the following annoying message is displayed _**"This setting is deprecated, please use 'java.jdt.ls.java.home' instead."**_

_This is my first pull request, I'm sorry if I'm missing something! I am a Brazilian programmer_ :brazil:.