### PR TITLE
Fix output channel ignoring showChannelOnServerOutput setting

### DIFF
--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -881,7 +881,8 @@ export class CommandHandler {
 
     private displayLog(outputPanel: vscode.OutputChannel, message: string, show = true) {
         if (outputPanel) {
-            if (show) outputPanel.show(true);
+            const showChannel = vscode.workspace.getConfiguration('vscodeAdapters').get<boolean>('showChannelOnServerOutput');
+            if (show && showChannel) outputPanel.show(true);
             outputPanel.appendLine(message);
         }
     }


### PR DESCRIPTION
## Summary
- `displayLog()` in `extensionApi.ts` unconditionally called `outputPanel.show()` for RSP stdout/stderr, stealing focus on every server output line
- The `showChannelOnServerOutput` setting was already checked in `serverExplorer.ts` for server output channels, but this separate codepath for the RSP process's own stdout/stderr was missed
- Now checks the setting before showing the output panel, consistent with the rest of the codebase

Fixes #285

## Test plan
- [ ] Set `vscodeAdapters.showChannelOnServerOutput` to `false`
- [ ] Start a server (e.g. Tomcat) and deploy an application
- [ ] Verify the output panel does NOT steal focus during server output or hot deployment
- [ ] Set the setting back to `true` and verify the output panel DOES show on server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)