### PR TITLE
Remember debug project name, stop prompting every session

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"onCommand:server.terminateRSP",
 		"onCommand:server.start",
 		"onCommand:server.debug",
+		"onCommand:server.debug.setProjectName",
 		"onCommand:server.stop",
 		"onCommand:server.terminate",
 		"onCommand:server.restart",
@@ -96,6 +97,11 @@
 			{
 				"command": "server.debug",
 				"title": "Debug Server",
+				"category": "Servers"
+			},
+			{
+				"command": "server.debug.setProjectName",
+				"title": "Set Debug Project Name...",
 				"category": "Servers"
 			},
 			{
@@ -300,6 +306,11 @@
 					"command": "server.editServer",
 					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
 					"group": "6_server-info@2"
+				},
+				{
+					"command": "server.debug.setProjectName",
+					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+					"group": "6_server-info@3"
 				}
 			],
 			"explorer/context": [

--- a/src/debug/javaDebugSession.ts
+++ b/src/debug/javaDebugSession.ts
@@ -37,28 +37,41 @@ export class JavaDebugSession {
     private async discoverProjectName(serverId: string): Promise<string | undefined> {
         const key = GLOBAL_STATE_SERVER_DEBUG_PROJECT_NAME_PREFIX + '/' + serverId;
         const currVal: string | undefined = myContext && myContext.globalState ? myContext.globalState.get(key) : undefined;
-        const val = await window.showInputBox({prompt: 'Please input a project name to be used by the java debugger.',
-            value: currVal || '', ignoreFocusOut: true});
-        if(val !== currVal) {
-            if(myContext && myContext.globalState)
-                myContext.globalState.update(key, val);
+        if (currVal) {
+            return currVal;
+        }
+        const val = await window.showInputBox({prompt: 'Please input a project name to be used by the java debugger. This will be remembered for future debug sessions.',
+            value: '', ignoreFocusOut: true});
+        if (val && myContext && myContext.globalState) {
+            myContext.globalState.update(key, val);
         }
         return val;
+    }
+
+    public async promptProjectName(serverId: string): Promise<void> {
+        const key = GLOBAL_STATE_SERVER_DEBUG_PROJECT_NAME_PREFIX + '/' + serverId;
+        const currVal: string | undefined = myContext && myContext.globalState ? myContext.globalState.get(key) : undefined;
+        const val = await window.showInputBox({prompt: 'Set the project name used by the java debugger for this server.',
+            value: currVal || '', ignoreFocusOut: true});
+        if (val !== undefined && myContext && myContext.globalState) {
+            myContext.globalState.update(key, val || undefined);
+        }
     }
 
     private async startDebugger(port: string, serverId: string) {
         this.port = port;
         const pName: string | undefined = await this.discoverProjectName(serverId);
-        const props = {
+        const props: vscode.DebugConfiguration = {
             type: 'java',
             request: 'attach',
             name: 'Debug (Remote)',
             hostName: 'localhost',
             port,
-            projectName: pName,
         };
-        const props2 = pName ? {...props, projectName: pName} : props;
-        vscode.debug.startDebugging(undefined, props2);
+        if (pName) {
+            props.projectName = pName;
+        }
+        vscode.debug.startDebugging(undefined, props);
     }
 
     public isDebuggerStarted(): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,8 @@ async function registerCommands(commandHandler: CommandHandler, context: vscode.
             commandHandler.restartServer, commandHandler, 'run', context, 'Unable to restart in run mode the server: ')),
         vscode.commands.registerCommand('server.debug', context => executeCommand(
             commandHandler.debugServer, commandHandler, context, 'Unable to debug the server: ')),
+        vscode.commands.registerCommand('server.debug.setProjectName', context => executeCommand(
+            commandHandler.setDebugProjectName, commandHandler, context, 'Unable to set debug project name: ')),
         vscode.commands.registerCommand('server.restartDebug', context => executeCommand(
             commandHandler.restartServer, commandHandler, 'debug', context, 'Unable to restart in debug mode the server: ')),
         vscode.commands.registerCommand('server.stop', context => executeCommand(

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -227,6 +227,17 @@ export class CommandHandler {
 
     }
 
+    public async setDebugProjectName(context?: ServerStateNode): Promise<void> {
+        if (context === undefined) {
+            const rsp = await this.selectRSP('Select RSP provider you want to retrieve servers');
+            if (!rsp || !rsp.id) return;
+            const serverId = await this.selectServer(rsp.id, 'Select server to set debug project name for');
+            if (!serverId) return;
+            context = this.explorer.getServerStateById(rsp.id, serverId);
+        }
+        await this.debugSession.promptProjectName(context.server.id);
+    }
+
     public async debugServer(context?: ServerStateNode): Promise<Protocol.StartServerResponse | undefined> {
         if (context === undefined) {
             const rsp = await this.selectRSP('Select RSP provider you want to retrieve servers');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -144,6 +144,7 @@ suite('Extension Tests', () => {
                 'server.downloadRuntime',
                 'server.actions',
                 'server.editServer',
+                'server.debug.setProjectName',
                 'server.application.run',
                 'server.application.debug',
                 'server.saveSelectedNode'


### PR DESCRIPTION
## Summary
- Skip the project name input box when a value is already stored for the server — users are only prompted on their first debug session
- Add a new **"Servers: Set Debug Project Name..."** command (command palette + server context menu) so users can change the stored name when needed
- Clean up redundant `projectName` assignment in `startDebugger`

Fixes #292
See also: redhat-developer/rsp-server-community#245

## Test plan
- [ ] Debug a server for the first time — should prompt for project name and remember it
- [ ] Debug the same server again — should attach without prompting
- [ ] Use "Set Debug Project Name..." from context menu or command palette to change the stored name
- [ ] Clear the project name (submit empty) via "Set Debug Project Name..." — next debug session should prompt again
- [ ] All 281 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)