### PR TITLE
Fixes #158 - switches license display to a read-only method

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@
 import { CommandHandler } from './extensionApi';
 import { ServerState } from 'rsp-client';
 import { getAPI } from './api/implementation/rspProviderAPI';
-import { ServerEditorAdapter } from './serverEditorAdapter';
+import { RSP_READONLY_SCHEME, ServerEditorAdapter } from './serverEditorAdapter';
 import { ServerExplorer } from './serverExplorer';
 import * as vscode from 'vscode';
 import { RSPModel } from 'vscode-server-connector-api';
@@ -24,6 +24,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<RSPMod
     serversExplorer = ServerExplorer.getInstance();
     commandHandler = new CommandHandler(serversExplorer);
     myContext = context;
+    const editorAdapter = ServerEditorAdapter.getInstance(serversExplorer);
+    context.subscriptions.push(
+        vscode.workspace.registerTextDocumentContentProvider(RSP_READONLY_SCHEME, editorAdapter.contentProvider)
+    );
     await registerCommands(commandHandler, context);
     registerRecommendations(context);
     return getAPI();

--- a/src/serverEditorAdapter.ts
+++ b/src/serverEditorAdapter.ts
@@ -15,11 +15,29 @@ export interface ServerProperties {
     file: string;
 }
 
+export const RSP_READONLY_SCHEME = 'rsp-readonly';
+
+export class ReadonlyContentProvider implements vscode.TextDocumentContentProvider {
+    private contents = new Map<string, string>();
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+    public readonly onDidChange = this._onDidChange.event;
+
+    public setContent(uri: vscode.Uri, content: string): void {
+        this.contents.set(uri.toString(), content);
+        this._onDidChange.fire(uri);
+    }
+
+    public provideTextDocumentContent(uri: vscode.Uri): string {
+        return this.contents.get(uri.toString()) || '';
+    }
+}
+
 export class ServerEditorAdapter {
 
     private static instance: ServerEditorAdapter;
     public RSPServerProperties: Map<string, ServerProperties[]> = new Map<string, ServerProperties[]>();
     private readonly PREFIX_TMP = 'tmpServerConnector';
+    public readonly contentProvider = new ReadonlyContentProvider();
 
     private constructor(private explorer: ServerExplorer) {
     }
@@ -33,18 +51,10 @@ export class ServerEditorAdapter {
 
     public async showEditor(fileSuffix: string, content: string, path?: string) : Promise<void> {
         if (!path) {
-            const newFile = vscode.Uri.parse(`untitled:${  fileSuffix}`);
-            await vscode.workspace.openTextDocument(newFile).then(async document => {
-                const edit = new vscode.WorkspaceEdit();
-                edit.insert(newFile, new vscode.Position(0, 0), content);
-                const success = await vscode.workspace.applyEdit(edit);
-                if (success) {
-                    vscode.window.showTextDocument(document);
-                }
-                else {
-                    vscode.window.showInformationMessage('Error Displaying Editor Content');
-                }
-            });
+            const uri = vscode.Uri.parse(`${RSP_READONLY_SCHEME}:${fileSuffix}`);
+            this.contentProvider.setContent(uri, content);
+            const document = await vscode.workspace.openTextDocument(uri);
+            await vscode.window.showTextDocument(document, { preview: true });
         } else {
             await vscode.workspace.openTextDocument(path).then(doc => {
                 vscode.window.showTextDocument(doc);

--- a/test/serverEditorAdapter.test.ts
+++ b/test/serverEditorAdapter.test.ts
@@ -90,41 +90,35 @@ suite('ServerEditorAdapter', () => {
     suite('showEditor', () => {
         test('check if parse method is called with right params', async () => {
             const parseStub = sandbox.stub(vscode.Uri, 'parse').returns(uriDoc);
+            sandbox.stub(vscode.workspace, 'openTextDocument').resolves(textDocument);
+            sandbox.stub(vscode.window, 'showTextDocument');
             await serverEditorAdapter.showEditor('suffix', 'content');
-            expect(parseStub).calledOnceWith('untitled:suffix');
+            expect(parseStub).calledOnceWith('rsp-readonly:suffix');
         });
 
         test('check if openTextDocument is called with right params', async () => {
             sandbox.stub(vscode.Uri, 'parse').returns(uriDoc);
             const openTextStub = sandbox.stub(vscode.workspace, 'openTextDocument').resolves(textDocument);
+            sandbox.stub(vscode.window, 'showTextDocument');
             await serverEditorAdapter.showEditor('suffix', 'content');
             expect(openTextStub).calledOnceWith(uriDoc);
         });
 
-        test('check if insert method is called with right params', async () => {
-            const edit = new vscode.WorkspaceEdit();
+        test('check if content is stored in the content provider', async () => {
             sandbox.stub(vscode.Uri, 'parse').returns(uriDoc);
             sandbox.stub(vscode.workspace, 'openTextDocument').resolves(textDocument);
-            sandbox.stub(vscode, 'WorkspaceEdit').returns(edit);
-            const insertStub = sandbox.stub(edit, 'insert');
+            sandbox.stub(vscode.window, 'showTextDocument');
+            const setContentStub = sandbox.stub(serverEditorAdapter.contentProvider, 'setContent');
             await serverEditorAdapter.showEditor('suffix', 'content');
-            expect(insertStub).calledOnceWith(uriDoc, new vscode.Position(0, 0), 'content');
+            expect(setContentStub).calledOnceWith(uriDoc, 'content');
         });
 
-        test('check if showTextDocument is called with right param if applyEdit succeed', async () => {
-            sandbox.stub(vscode.workspace, 'applyEdit').resolves(true);
+        test('check if showTextDocument is called with right params', async () => {
+            sandbox.stub(vscode.Uri, 'parse').returns(uriDoc);
             sandbox.stub(vscode.workspace, 'openTextDocument').resolves(textDocument);
             const showTextStub = sandbox.stub(vscode.window, 'showTextDocument');
             await serverEditorAdapter.showEditor('suffix', 'content');
-            expect(showTextStub).calledOnceWith(textDocument);
-        });
-
-        test('check if showInformationMessage is called with right param if applyEdit fails', async () => {
-            sandbox.stub(vscode.workspace, 'applyEdit').resolves(false);
-            sandbox.stub(vscode.workspace, 'openTextDocument').resolves(textDocument);
-            const showInfoStub = sandbox.stub(vscode.window, 'showInformationMessage');
-            await serverEditorAdapter.showEditor('suffix', 'content');
-            expect(showInfoStub).calledOnceWith('Error Displaying Editor Content');
+            expect(showTextStub).calledOnceWith(textDocument, { preview: true });
         });
     });
 


### PR DESCRIPTION
Added a ReadonlyContentProvider in serverEditorAdapter.ts that stores virtual document content keyed by URI.
showEditor now opens documents via the rsp-readonly: scheme instead of untitled:, so VS Code treats them as read-only automatically.