### PR TITLE
Fixes #93 - enables canSelectMany on remove server, remove deployment…

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,57 +204,57 @@
 			"view/item/context": [
 				{
 					"command": "server.startRSP",
-					"when": "view == servers && viewItem =~ /^(RSPUnknown|RSPStopped)/",
+					"when": "view == servers && viewItem =~ /^(RSPUnknown|RSPStopped)/ && !listMultiSelection",
 					"group": "0_server-rspstartstop@1"
 				},
 				{
 					"command": "server.disconnectRSP",
-					"when": "view == servers && viewItem =~ /^(RSPConnected)/",
+					"when": "view == servers && viewItem =~ /^(RSPConnected)/ && !listMultiSelection",
 					"group": "0_server-rspstartstop@2"
 				},
 				{
 					"command": "server.stopRSP",
-					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPConnected)/",
+					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPConnected)/ && !listMultiSelection",
 					"group": "0_server-rspstartstop@2"
 				},
 				{
 					"command": "server.terminateRSP",
-					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPStarting|RSPStopping)/",
+					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPStarting|RSPStopping)/ && !listMultiSelection",
 					"group": "0_server-rspstartstop@2"
 				},
 				{
 					"command": "server.createServer",
-					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPConnected)/",
+					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPConnected)/ && !listMultiSelection",
 					"group": "0_server-rspstartstop@3"
 				},
 				{
 					"command": "server.start",
-					"when": "view == servers && viewItem =~ /^(Stopped|Unknown)/",
+					"when": "view == servers && viewItem =~ /^(Stopped|Unknown)/ && !listMultiSelection",
 					"group": "1_server-startstop@1"
 				},
 				{
 					"command": "server.debug",
-					"when": "view == servers && viewItem =~ /^Stopped/",
+					"when": "view == servers && viewItem =~ /^Stopped/ && !listMultiSelection",
 					"group": "1_server-startstop@2"
 				},
 				{
 					"command": "server.stop",
-					"when": "view == servers && viewItem =~ /^(Started|Debugging|Unknown)/",
+					"when": "view == servers && viewItem =~ /^(Started|Debugging|Unknown)/ && !listMultiSelection",
 					"group": "1_server-startstop@3"
 				},
 				{
 					"command": "server.restart",
-					"when": "view == servers && viewItem =~ /^(Started|Debugging)/",
+					"when": "view == servers && viewItem =~ /^(Started|Debugging)/ && !listMultiSelection",
 					"group": "1_server-startstop@4"
 				},
 				{
 					"command": "server.restartDebug",
-					"when": "view == servers && viewItem =~ /^(Started|Debugging)/",
+					"when": "view == servers && viewItem =~ /^(Started|Debugging)/ && !listMultiSelection",
 					"group": "1_server-startstop@5"
 				},
 				{
 					"command": "server.terminate",
-					"when": "view == servers && viewItem =~ /^(Starting|Stopping|Started|Stopped|Unknown)/",
+					"when": "view == servers && viewItem =~ /^(Starting|Stopping|Started|Stopped|Unknown)/ && !listMultiSelection",
 					"group": "1_server-startstop@6"
 				},
 				{
@@ -274,7 +274,7 @@
 				},
 				{
 					"command": "server.addDeployment",
-					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|^Unknown)/",
+					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|^Unknown)/ && !listMultiSelection",
 					"group": "3_server-deployments@1"
 				},
 				{
@@ -284,7 +284,7 @@
 				},
 				{
 					"command": "server.output",
-					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped)/",
+					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped)/ && !listMultiSelection",
 					"group": "4_server-status@1"
 				},
 				{
@@ -299,12 +299,12 @@
 				},
 				{
 					"command": "server.actions",
-					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/ && !listMultiSelection",
 					"group": "6_server-info@1"
 				},
 				{
 					"command": "server.editServer",
-					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
+					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/ && !listMultiSelection",
 					"group": "6_server-info@2"
 				},
 				{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,18 +67,18 @@ async function registerCommands(commandHandler: CommandHandler, context: vscode.
             commandHandler.stopServer, commandHandler, false, context, 'Unable to stop the server: ')),
         vscode.commands.registerCommand('server.terminate', context => executeCommand(
             commandHandler.stopServer, commandHandler, true, context, 'Unable to terminate the server: ')),
-        vscode.commands.registerCommand('server.remove', context => executeCommand(
-            commandHandler.removeServer, commandHandler, context, 'Unable to remove the server: ')),
+        vscode.commands.registerCommand('server.remove', (context, selected) => executeCommand(
+            commandHandler.removeServer, commandHandler, context, selected, 'Unable to remove the server: ')),
         vscode.commands.registerCommand('server.output', context => executeCommand(
             commandHandler.showServerOutput, commandHandler, context, 'Unable to show server output channel')),
         vscode.commands.registerCommand('server.addDeployment', context => executeCommand(
             commandHandler.addDeployment, commandHandler, context, 'Unable to add deployment to the server: ')),
-        vscode.commands.registerCommand('server.removeDeployment', context => executeCommand(
-            commandHandler.removeDeployment, commandHandler, context, 'Unable to remove deployment from the server: ')),
-        vscode.commands.registerCommand('server.publishFull', context => executeCommand(
-            commandHandler.publishServer, commandHandler, ServerState.PUBLISH_FULL, context, 'Unable to publish (Full) to the server: ')),
-        vscode.commands.registerCommand('server.publishIncremental', context => executeCommand(
-            commandHandler.publishServer, commandHandler, ServerState.PUBLISH_INCREMENTAL, context, 'Unable to publish (Incremental) to the server: ')),
+        vscode.commands.registerCommand('server.removeDeployment', (context, selected) => executeCommand(
+            commandHandler.removeDeployment, commandHandler, context, selected, 'Unable to remove deployment from the server: ')),
+        vscode.commands.registerCommand('server.publishFull', (context, selected) => executeCommand(
+            commandHandler.publishServer, commandHandler, ServerState.PUBLISH_FULL, context, selected, 'Unable to publish (Full) to the server: ')),
+        vscode.commands.registerCommand('server.publishIncremental', (context, selected) => executeCommand(
+            commandHandler.publishServer, commandHandler, ServerState.PUBLISH_INCREMENTAL, context, selected, 'Unable to publish (Incremental) to the server: ')),
         vscode.commands.registerCommand('server.editServer', context => executeCommand(
             commandHandler.editServer, commandHandler, context, 'Unable to edit server properties')),
         vscode.commands.registerCommand('server.actions', context => executeCommand(

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -280,20 +280,38 @@ export class CommandHandler {
             });
     }
 
-    public async removeServer(context?: ServerStateNode): Promise<Protocol.Status> {
-        if (context === undefined) {
+    public async removeServer(context?: ServerStateNode, selected?: ServerStateNode[]): Promise<Protocol.Status> {
+        const nodes = this.resolveNodes(context, selected);
+        if (!nodes || nodes.length === 0) {
             const rsp = await this.selectRSP('Select RSP provider you want to retrieve servers');
             if (!rsp || !rsp.id) return null;
             const serverFilter = server => server.state === ServerState.STOPPED || server.state === ServerState.UNKNOWN;
             const serverId = await this.selectServer(rsp.id, 'Select server to remove', serverFilter);
             if (!serverId) return null;
             context = this.explorer.getServerStateById(rsp.id, serverId);
+            return this.removeSingleServer(context);
         }
-        const telemetryProps: any = {
-            type: context.server.type.id,
-        };
-        sendTelemetry('server.remove', telemetryProps);
+        if (!this.allSameRSP(nodes)) {
+            vscode.window.showErrorMessage('Cannot remove servers from different RSP providers at once.');
+            return null;
+        }
+        if (nodes.length === 1) {
+            return this.removeSingleServer(nodes[0]);
+        }
+        const names = nodes.map(n => n.server.id).join(', ');
+        const remove = await vscode.window.showWarningMessage(
+            `Remove ${nodes.length} servers (${names})?`, { modal: true }, 'Yes');
+        if (!remove) return null;
+        let lastStatus: Protocol.Status = null;
+        for (const node of nodes) {
+            sendTelemetry('server.remove', { type: node.server.type.id });
+            lastStatus = await this.removeStoppedServer(node.rsp, node.server);
+        }
+        return lastStatus;
+    }
 
+    private async removeSingleServer(context: ServerStateNode): Promise<Protocol.Status> {
+        sendTelemetry('server.remove', { type: context.server.type.id });
         const remove = await vscode.window.showWarningMessage(
             `Remove server ${context.server.id}?`, { modal: true }, 'Yes');
         return remove && this.removeStoppedServer(context.rsp, context.server);
@@ -413,8 +431,9 @@ export class CommandHandler {
 
     }
 
-    public async removeDeployment(context?: DeployableStateNode): Promise<Protocol.Status> {
-        if (context === undefined) {
+    public async removeDeployment(context?: DeployableStateNode, selected?: DeployableStateNode[]): Promise<Protocol.Status> {
+        const nodes = this.resolveNodes(context, selected);
+        if (!nodes || nodes.length === 0) {
             const rsp = await this.selectRSP('Select RSP provider you want to retrieve servers');
             if (!rsp || !rsp.id) return null;
             const serverFilter = server => server.publishState === ServerState.PUBLISH_STATE_NONE ||
@@ -434,24 +453,43 @@ export class CommandHandler {
             const deployment = await vscode.window.showQuickPick(deployables, { placeHolder: 'Select deployment to remove' });
             if (!deployment || !deployment.deployable) return null;
             context = deployment.deployable;
+            sendTelemetry('server.removeDeployment', { type: context.server.type.id });
+            return this.explorer.removeDeployment(context.rsp, context.server, context.reference);
         }
-
-        const telemetryProps: any = {
-            type: context.server.type.id,
-        };
-        sendTelemetry('server.removeDeployment', telemetryProps);
-
-        return this.explorer.removeDeployment(context.rsp, context.server, context.reference);
+        if (!this.allSameServer(nodes)) {
+            vscode.window.showErrorMessage('Cannot remove deployments from different servers at once.');
+            return null;
+        }
+        let lastStatus: Protocol.Status = null;
+        for (const node of nodes) {
+            sendTelemetry('server.removeDeployment', { type: node.server.type.id });
+            lastStatus = await this.explorer.removeDeployment(node.rsp, node.server, node.reference);
+        }
+        return lastStatus;
     }
 
-    public async publishServer(publishType: number, context?: ServerStateNode): Promise<Protocol.Status> {
-        if (context === undefined) {
+    public async publishServer(publishType: number, context?: ServerStateNode, selected?: ServerStateNode[]): Promise<Protocol.Status> {
+        const nodes = this.resolveNodes(context, selected);
+        if (!nodes || nodes.length === 0) {
             const rsp = await this.selectRSP('Select RSP provider you want to retrieve servers');
             if (!rsp || !rsp.id) return null;
             const serverId = await this.selectServer(rsp.id, 'Select server to publish');
             if (!serverId) return null;
             context = this.explorer.getServerStateById(rsp.id, serverId);
+            return this.publishSingleServer(publishType, context);
         }
+        if (!this.allSameRSP(nodes)) {
+            vscode.window.showErrorMessage('Cannot publish servers from different RSP providers at once.');
+            return null;
+        }
+        let lastStatus: Protocol.Status = null;
+        for (const node of nodes) {
+            lastStatus = await this.publishSingleServer(publishType, node);
+        }
+        return lastStatus;
+    }
+
+    private async publishSingleServer(publishType: number, context: ServerStateNode): Promise<Protocol.Status> {
         const isAsync = vscode.workspace.getConfiguration('rsp-ui').get<boolean>('enableAsyncPublish');
 
         const telemetryProps: any = {
@@ -920,5 +958,23 @@ export class CommandHandler {
         client.getIncomingHandler().onServerProcessOutputAppended(event => {
             this.explorer.addServerOutput(event);
         });
+    }
+
+    private resolveNodes<T>(context: T | undefined, selected: T[] | undefined): T[] | undefined {
+        if (selected && selected.length > 0) {
+            return selected;
+        }
+        if (context) {
+            return [context];
+        }
+        return undefined;
+    }
+
+    private allSameRSP(nodes: ServerStateNode[]): boolean {
+        return nodes.every(n => n.rsp === nodes[0].rsp);
+    }
+
+    private allSameServer(nodes: DeployableStateNode[]): boolean {
+        return nodes.every(n => n.rsp === nodes[0].rsp && n.server.id === nodes[0].server.id);
     }
 }

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -87,7 +87,7 @@ export class ServerExplorer implements TreeDataProvider<RSPState | ServerStateNo
     public nodeSelected: RSPState | ServerStateNode;
 
     private constructor() {
-        this.viewer = window.createTreeView('servers', { treeDataProvider: this });
+        this.viewer = window.createTreeView('servers', { treeDataProvider: this, canSelectMany: true });
         this.viewer.onDidChangeVisibility(this.changeViewer, this);
 
         this.runStateEnum


### PR DESCRIPTION
…s, and publish server


  Here's a summary of the changes:

  Tree view (serverExplorer.ts): Enabled canSelectMany: true.

  Command wiring (extension.ts): server.remove, server.removeDeployment, server.publishFull, and
  server.publishIncremental now pass (context, selected) through to their handlers.

  Command handlers (extensionApi.ts):
  - removeServer — accepts multi-selection, validates all servers are under the same RSP, shows a combined
  confirmation prompt
  - publishServer — accepts multi-selection, validates same RSP, publishes each sequentially
  - removeDeployment — accepts multi-selection, validates all deployments belong to the same server, removes each
  sequentially
  - Added resolveNodes, allSameRSP, allSameServer helpers

  Context menus (package.json): Added && !listMultiSelection to all commands that don't support multi-select (start,
  stop, debug, restart, terminate, RSP commands, output, actions, editServer, addDeployment). Remove, publish, and
  removeDeployment remain visible during multi-select.

