### PR TITLE
Fixes #322 - Add export/import server descriptor commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
 		"onCommand:server.disconnectRSP",
 		"onCommand:server.stopRSP",
 		"onCommand:server.terminateRSP",
+		"onCommand:server.exportDescriptor",
+		"onCommand:server.importDescriptor",
 		"onCommand:server.start",
 		"onCommand:server.debug",
 		"onCommand:server.debug.setProjectName",
@@ -165,6 +167,16 @@
 				"category": "Servers"
 			},
 			{
+				"command": "server.exportDescriptor",
+				"title": "Export Server Descriptor...",
+				"category": "Servers"
+			},
+			{
+				"command": "server.importDescriptor",
+				"title": "Import Server from Descriptor...",
+				"category": "Servers"
+			},
+			{
 				"command": "server.application.run",
 				"title": "Run on Server",
 				"category": "Application"
@@ -226,6 +238,11 @@
 					"command": "server.createServer",
 					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPConnected)/",
 					"group": "0_server-rspstartstop@3"
+				},
+				{
+					"command": "server.importDescriptor",
+					"when": "view == servers && viewItem =~ /^(RSPStarted|RSPConnected)/ && !listMultiSelection",
+					"group": "0_server-rspstartstop@4"
 				},
 				{
 					"command": "server.start",
@@ -308,9 +325,14 @@
 					"group": "6_server-info@2"
 				},
 				{
+					"command": "server.exportDescriptor",
+					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/ && !listMultiSelection",
+					"group": "6_server-info@3"
+				},
+				{
 					"command": "server.debug.setProjectName",
 					"when": "view == servers && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/",
-					"group": "6_server-info@3"
+					"group": "6_server-info@4"
 				}
 			],
 			"explorer/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,6 +93,11 @@ async function registerCommands(commandHandler: CommandHandler, context: vscode.
         vscode.commands.registerCommand('server.createServer', context => executeCommandAndLog('server.createServer',
             commandHandler.createServer, commandHandler, context, 'Unable to create the server: ')),
 
+        vscode.commands.registerCommand('server.exportDescriptor', context => executeCommand(
+            commandHandler.exportDescriptor, commandHandler, context, 'Unable to export server descriptor: ')),
+        vscode.commands.registerCommand('server.importDescriptor', context => executeCommand(
+            commandHandler.importDescriptor, commandHandler, context, 'Unable to import server descriptor: ')),
+
         // Do these two still exist? Can't seem to get them to show up
         vscode.commands.registerCommand('server.addLocation', context => executeCommandAndLog('server.addLocation',
             commandHandler.addLocation, commandHandler, context, 'Unable to detect any server: ')),

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -11,6 +11,7 @@ import { DebugInfoProvider } from './debug/debugInfoProvider';
 import { JavaDebugSession } from './debug/javaDebugSession';
 import { Protocol, RSPClient, ServerState, StatusSeverity } from 'rsp-client';
 import { DeployableStateNode, RSPProperties, RSPState, ServerExplorer, ServerStateNode } from './serverExplorer';
+import { exportServerDescriptor, importServerDescriptor } from './serverDescriptor';
 import { Utils } from './utils/utils';
 import * as vscode from 'vscode';
 import { RSPController, ServerInfo } from 'vscode-server-connector-api';
@@ -700,6 +701,41 @@ export class CommandHandler {
         }
         return Promise.reject('Runtime Server Protocol (RSP) Server is starting, please try again later.');
 
+    }
+
+    public async exportDescriptor(context?: ServerStateNode): Promise<void> {
+        if (context === undefined) {
+            const rsp = await this.selectRSP('Select RSP provider you want to retrieve servers');
+            if (!rsp || !rsp.id) return;
+            const serverId = await this.selectServer(rsp.id, 'Select server to export');
+            if (!serverId) return;
+            context = this.explorer.getServerStateById(rsp.id, serverId);
+        }
+
+        const client: RSPClient = this.explorer.getClientByRSP(context.rsp);
+        if (!client) {
+            return Promise.reject('Failed to contact the RSP server.');
+        }
+
+        sendTelemetry('server.exportDescriptor', { type: context.server.type.id });
+        return exportServerDescriptor(context.rsp, context.server, client);
+    }
+
+    public async importDescriptor(context?: RSPState): Promise<void> {
+        this.assertExplorerExists();
+        if (context === undefined) {
+            const rsp = await this.selectRSP('Select RSP provider to import server descriptor into');
+            if (!rsp || !rsp.id) return;
+            context = this.explorer.RSPServersStatus.get(rsp.id).state;
+        }
+
+        const client: RSPClient = this.explorer.getClientByRSP(context.type.id);
+        if (!client) {
+            return Promise.reject('Failed to contact the RSP server.');
+        }
+
+        sendTelemetry('server.importDescriptor', { rspType: context.type.id });
+        await importServerDescriptor(context.type.id, client, this.explorer);
     }
 
     public async runOnServer(uri: vscode.Uri, mode?: string): Promise<void> {

--- a/src/serverDescriptor.ts
+++ b/src/serverDescriptor.ts
@@ -1,0 +1,237 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the EPL v2.0 License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { Protocol, RSPClient, StatusSeverity } from 'rsp-client';
+import { ServerExplorer } from './serverExplorer';
+import * as vscode from 'vscode';
+
+const VARIABLE_PREFIX = '${rsp_import_export/';
+const VARIABLE_SUFFIX = '}';
+const FORMAT_VERSION_KEY = 'rsp.descriptor.format.version';
+const FORMAT_VERSION = '1.0';
+const TYPE_ID_KEY = 'org.jboss.tools.rsp.server.typeId';
+const EXCLUDED_EXPORT_KEYS = new Set(['id', 'deployables']);
+
+function isFilesystemPath(value: string): boolean {
+    if (typeof value !== 'string' || value.length === 0) return false;
+    const trimmed = value.trim();
+
+    if (trimmed.startsWith('file://')) return true;
+
+    if (trimmed.startsWith('/')) {
+        const segments = trimmed.split('/').filter(s => s.length > 0);
+        return segments.length >= 2;
+    }
+
+    if (/^[A-Za-z]:[\\\/]/.test(trimmed)) return true;
+
+    return false;
+}
+
+function detectPathAttributes(attrs: Record<string, any>): Map<string, string> {
+    const pathAttrs = new Map<string, string>();
+    for (const [key, value] of Object.entries(attrs)) {
+        if (EXCLUDED_EXPORT_KEYS.has(key) || key === FORMAT_VERSION_KEY || key === TYPE_ID_KEY) continue;
+        if (typeof value === 'string' && isFilesystemPath(value)) {
+            pathAttrs.set(key, value);
+        }
+    }
+    return pathAttrs;
+}
+
+function substitutePathsForExport(attrs: Record<string, any>): Record<string, any> {
+    const pathAttrs = detectPathAttributes(attrs);
+
+    const sortedPaths = [...pathAttrs.entries()]
+        .sort((a, b) => b[1].length - a[1].length);
+
+    const result: Record<string, any> = {};
+    result[FORMAT_VERSION_KEY] = FORMAT_VERSION;
+
+    for (const [key, value] of Object.entries(attrs)) {
+        if (EXCLUDED_EXPORT_KEYS.has(key)) continue;
+
+        if (typeof value !== 'string') {
+            result[key] = value;
+            continue;
+        }
+
+        let newValue = value;
+        for (const [pathKey, pathValue] of sortedPaths) {
+            const variable = `${VARIABLE_PREFIX}${pathKey}${VARIABLE_SUFFIX}`;
+            while (newValue.includes(pathValue)) {
+                newValue = newValue.split(pathValue).join(variable);
+            }
+        }
+        result[key] = newValue;
+    }
+
+    return result;
+}
+
+function findVariables(attrs: Record<string, any>): string[] {
+    const variables = new Set<string>();
+    const regex = /\$\{rsp_import_export\/([^}]+)\}/g;
+
+    for (const value of Object.values(attrs)) {
+        if (typeof value !== 'string') continue;
+        let match;
+        while ((match = regex.exec(value)) !== null) {
+            variables.add(match[1]);
+        }
+        regex.lastIndex = 0;
+    }
+    return [...variables];
+}
+
+function resolveVariables(attrs: Record<string, any>, values: Map<string, string>): Record<string, any> {
+    const result: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(attrs)) {
+        if (key === FORMAT_VERSION_KEY) continue;
+
+        if (typeof value !== 'string') {
+            result[key] = value;
+            continue;
+        }
+
+        let newValue = value;
+        for (const [varKey, varValue] of values.entries()) {
+            const variable = `${VARIABLE_PREFIX}${varKey}${VARIABLE_SUFFIX}`;
+            while (newValue.includes(variable)) {
+                newValue = newValue.split(variable).join(varValue);
+            }
+        }
+        result[key] = newValue;
+    }
+
+    return result;
+}
+
+export async function exportServerDescriptor(
+    rspId: string,
+    server: Protocol.ServerHandle,
+    client: RSPClient
+): Promise<void> {
+    const serverJson = await client.getOutgoingHandler().getServerAsJson(server);
+    if (!serverJson || !serverJson.serverJson) {
+        throw new Error(`Could not retrieve server properties for ${server.id}`);
+    }
+
+    const attrs = JSON.parse(serverJson.serverJson);
+    const exported = substitutePathsForExport(attrs);
+    const content = JSON.stringify(exported, null, 2);
+
+    const defaultName = server.id.replace(/[^a-zA-Z0-9_.-]/g, '_');
+    const workspaceFolder = (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0)
+        ? vscode.workspace.workspaceFolders[0].uri
+        : undefined;
+    const defaultUri = workspaceFolder
+        ? vscode.Uri.joinPath(workspaceFolder, `${defaultName}.server.json`)
+        : vscode.Uri.file(`${defaultName}.server.json`);
+
+    const uri = await vscode.window.showSaveDialog({
+        defaultUri,
+        filters: { 'RSP Server Descriptor': ['json'] },
+        title: 'Export Server Descriptor'
+    });
+
+    if (!uri) return;
+
+    await vscode.workspace.fs.writeFile(uri, Buffer.from(content, 'utf-8'));
+    vscode.window.showInformationMessage(`Server descriptor exported to ${uri.fsPath}`);
+}
+
+export async function importServerDescriptor(
+    rspId: string,
+    client: RSPClient,
+    explorer: ServerExplorer
+): Promise<Protocol.CreateServerResponse | undefined> {
+    const files = await vscode.window.showOpenDialog({
+        canSelectFiles: true,
+        canSelectFolders: false,
+        canSelectMany: false,
+        filters: { 'RSP Server Descriptor': ['json'] },
+        title: 'Select Server Descriptor File'
+    });
+
+    if (!files || files.length === 0) return;
+
+    const fileContent = await vscode.workspace.fs.readFile(files[0]);
+    const attrs: Record<string, any> = JSON.parse(Buffer.from(fileContent).toString('utf-8'));
+
+    const serverTypeId = attrs[TYPE_ID_KEY];
+    if (!serverTypeId) {
+        throw new Error('Descriptor file does not contain a server type ID (org.jboss.tools.rsp.server.typeId)');
+    }
+
+    const serverTypes = await client.getOutgoingHandler().getServerTypes();
+    const serverType = serverTypes.find(t => t.id === serverTypeId);
+    if (!serverType) {
+        throw new Error(
+            `This RSP does not support server type "${serverTypeId}". ` +
+            'Make sure you are importing to the correct RSP provider.'
+        );
+    }
+
+    const variables = findVariables(attrs);
+    const variableValues = new Map<string, string>();
+
+    for (const varKey of variables) {
+        const isFileKey = /\.file\b/i.test(varKey) && !/\.dir\b/i.test(varKey);
+        const result = await vscode.window.showOpenDialog({
+            canSelectFiles: isFileKey,
+            canSelectFolders: !isFileKey,
+            canSelectMany: false,
+            title: `Select path for: ${varKey}`,
+            openLabel: `Select (${varKey})`
+        });
+
+        if (!result || result.length === 0) return;
+        variableValues.set(varKey, result[0].fsPath);
+    }
+
+    const resolved = resolveVariables(attrs, variableValues);
+
+    const defaultName = explorer.getDefaultServerName(rspId, serverType);
+    const serverName = await vscode.window.showInputBox({
+        prompt: `Enter a name for the new ${serverType.visibleName} server`,
+        value: defaultName,
+        validateInput: (value) => {
+            if (!value || value.trim().length === 0) {
+                return 'Server name cannot be empty';
+            }
+            const existing = explorer.getServerStatesByRSP(rspId);
+            if (existing.find(s => s.server.id === value)) {
+                return 'A server with this name already exists';
+            }
+            return undefined;
+        }
+    });
+
+    if (!serverName) return;
+
+    const serverAttrs: Record<string, any> = {};
+    for (const [key, value] of Object.entries(resolved)) {
+        if (key === TYPE_ID_KEY || key === 'id' || key === FORMAT_VERSION_KEY) continue;
+        serverAttrs[key] = value;
+    }
+
+    const createParams: Protocol.ServerAttributes = {
+        serverType: serverTypeId,
+        id: serverName,
+        attributes: serverAttrs
+    };
+
+    const response = await client.getOutgoingHandler().createServer(createParams);
+    if (!StatusSeverity.isOk(response.status)) {
+        throw new Error(response.status.message);
+    }
+
+    vscode.window.showInformationMessage(`Server "${serverName}" created from descriptor`);
+    return response;
+}

--- a/src/serverDescriptor.ts
+++ b/src/serverDescriptor.ts
@@ -7,7 +7,10 @@
 
 import { Protocol, RSPClient, StatusSeverity } from 'rsp-client';
 import { ServerExplorer } from './serverExplorer';
+import { myContext } from './extension';
 import * as vscode from 'vscode';
+import { IWizardPage, SEVERITY, ValidatorResponseItem, WebviewWizard, WizardDefinition, WizardPageFieldDefinition, WizardPageSectionDefinition } from '@redhat-developer/vscode-wizard';
+import { PerformFinishResponse } from '@redhat-developer/vscode-wizard/lib/IWizardWorkflowManager';
 
 const VARIABLE_PREFIX = '${rsp_import_export/';
 const VARIABLE_SUFFIX = '}';
@@ -150,7 +153,7 @@ export async function importServerDescriptor(
     rspId: string,
     client: RSPClient,
     explorer: ServerExplorer
-): Promise<Protocol.CreateServerResponse | undefined> {
+): Promise<void> {
     const files = await vscode.window.showOpenDialog({
         canSelectFiles: true,
         canSelectFolders: false,
@@ -179,59 +182,147 @@ export async function importServerDescriptor(
     }
 
     const variables = findVariables(attrs);
-    const variableValues = new Map<string, string>();
-
-    for (const varKey of variables) {
-        const isFileKey = /\.file\b/i.test(varKey) && !/\.dir\b/i.test(varKey);
-        const result = await vscode.window.showOpenDialog({
-            canSelectFiles: isFileKey,
-            canSelectFolders: !isFileKey,
-            canSelectMany: false,
-            title: `Select path for: ${varKey}`,
-            openLabel: `Select (${varKey})`
-        });
-
-        if (!result || result.length === 0) return;
-        variableValues.set(varKey, result[0].fsPath);
-    }
-
-    const resolved = resolveVariables(attrs, variableValues);
-
     const defaultName = explorer.getDefaultServerName(rspId, serverType);
-    const serverName = await vscode.window.showInputBox({
-        prompt: `Enter a name for the new ${serverType.visibleName} server`,
-        value: defaultName,
-        validateInput: (value) => {
-            if (!value || value.trim().length === 0) {
-                return 'Server name cannot be empty';
-            }
-            const existing = explorer.getServerStatesByRSP(rspId);
-            if (existing.find(s => s.server.id === value)) {
-                return 'A server with this name already exists';
-            }
-            return undefined;
-        }
+
+    const initialData: Map<string, string> = new Map<string, string>();
+    initialData.set('id', defaultName);
+
+    const fields: (WizardPageFieldDefinition | WizardPageSectionDefinition)[] = [];
+
+    fields.push({
+        id: 'id',
+        type: 'textbox',
+        label: 'Server Name*',
+        initialValue: defaultName
     });
 
-    if (!serverName) return;
+    if (variables.length > 0) {
+        const pathFields: WizardPageFieldDefinition[] = variables.map(varKey => {
+            const isFileKey = /\.file\b/i.test(varKey) && !/\.dir\b/i.test(varKey);
+            const field: WizardPageFieldDefinition = {
+                id: `var_${varKey}`,
+                type: 'file-picker',
+                label: `${varKey}*`,
+                description: `Local path for ${varKey}`,
+                initialValue: ''
+            };
+            if (!isFileKey) {
+                field.dialogOptions = {
+                    canSelectFiles: false,
+                    canSelectFolders: true,
+                    canSelectMany: false,
+                    openLabel: `Select folder for ${varKey}`
+                };
+            }
+            return field;
+        });
 
-    const serverAttrs: Record<string, any> = {};
-    for (const [key, value] of Object.entries(resolved)) {
-        if (key === TYPE_ID_KEY || key === 'id' || key === FORMAT_VERSION_KEY) continue;
-        serverAttrs[key] = value;
+        fields.push({
+            id: 'pathVariablesSection',
+            label: 'Local Paths',
+            description: 'These paths were detected as machine-specific in the descriptor. Select the local path for each.',
+            childFields: pathFields
+        } as WizardPageSectionDefinition);
     }
 
-    const createParams: Protocol.ServerAttributes = {
-        serverType: serverTypeId,
-        id: serverName,
-        attributes: serverAttrs
+    const def: WizardDefinition = {
+        title: `Import Server: ${serverType.visibleName}`,
+        description: `Create a new ${serverType.visibleName} server from a shared descriptor file.`,
+        pages: [
+            {
+                id: 'importPage1',
+                title: 'Import Server from Descriptor',
+                description: 'Provide a server name and fill in any machine-specific paths.',
+                fields,
+                validator: (parameters: any) => {
+                    const errors: ValidatorResponseItem[] = [];
+                    if (!parameters.id || parameters.id === '') {
+                        errors.push({
+                            template: { id: 'idValidation', content: 'Server name must not be empty.' },
+                            severity: SEVERITY.ERROR
+                        });
+                    } else {
+                        const existing = explorer.getServerStatesByRSP(rspId);
+                        if (existing.find(s => s.server.id === parameters.id)) {
+                            errors.push({
+                                template: { id: 'idValidation', content: 'A server with this name already exists.' },
+                                severity: SEVERITY.ERROR
+                            });
+                        }
+                    }
+                    for (const varKey of variables) {
+                        const fieldId = `var_${varKey}`;
+                        if (!parameters[fieldId] || parameters[fieldId] === '') {
+                            errors.push({
+                                template: { id: `${fieldId}Validation`, content: `${varKey} must not be empty.` },
+                                severity: SEVERITY.ERROR
+                            });
+                        }
+                    }
+                    return { items: errors };
+                }
+            }
+        ],
+        workflowManager: {
+            canFinish(_wizard: WebviewWizard, data: any): boolean {
+                if (!data.id || data.id === '') return false;
+                for (const varKey of variables) {
+                    if (!data[`var_${varKey}`] || data[`var_${varKey}`] === '') return false;
+                }
+                return true;
+            },
+            async performFinish(_wizard: WebviewWizard, data: any): Promise<PerformFinishResponse | null> {
+                try {
+                    const variableValues = new Map<string, string>();
+                    for (const varKey of variables) {
+                        variableValues.set(varKey, data[`var_${varKey}`]);
+                    }
+
+                    const resolved = resolveVariables(attrs, variableValues);
+
+                    const serverAttrs: Record<string, any> = {};
+                    for (const [key, value] of Object.entries(resolved)) {
+                        if (key === TYPE_ID_KEY || key === 'id' || key === FORMAT_VERSION_KEY) continue;
+                        serverAttrs[key] = value;
+                    }
+
+                    const createParams: Protocol.ServerAttributes = {
+                        serverType: serverTypeId,
+                        id: data.id,
+                        attributes: serverAttrs
+                    };
+
+                    const response = await client.getOutgoingHandler().createServer(createParams);
+                    if (!StatusSeverity.isOk(response.status)) {
+                        return {
+                            close: false,
+                            success: false,
+                            returnObject: {},
+                            templates: [{ id: 'description', content: response.status.message }]
+                        };
+                    }
+
+                    vscode.window.showInformationMessage(`Server "${data.id}" created from descriptor`);
+                    return null;
+                } catch (e) {
+                    return {
+                        close: false,
+                        success: false,
+                        returnObject: {},
+                        templates: [{ id: 'description', content: String(e) }]
+                    };
+                }
+            },
+            getNextPage(_page: IWizardPage, _data: any): IWizardPage | null {
+                return null;
+            },
+            getPreviousPage(_page: IWizardPage, _data: any): IWizardPage | null {
+                return null;
+            }
+        }
     };
 
-    const response = await client.getOutgoingHandler().createServer(createParams);
-    if (!StatusSeverity.isOk(response.status)) {
-        throw new Error(response.status.message);
-    }
-
-    vscode.window.showInformationMessage(`Server "${serverName}" created from descriptor`);
-    return response;
+    const wiz = new WebviewWizard('Import Server Wizard', 'ImportServerWizard',
+        myContext, def, initialData);
+    wiz.open();
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -145,6 +145,8 @@ suite('Extension Tests', () => {
                 'server.actions',
                 'server.editServer',
                 'server.debug.setProjectName',
+                'server.exportDescriptor',
+                'server.importDescriptor',
                 'server.application.run',
                 'server.application.debug',
                 'server.saveSelectedNode'


### PR DESCRIPTION
Adds two new commands to allow users to export a server adapter's configuration to a shareable JSON file and import it back on another machine. On export, filesystem paths are auto-detected and replaced with ${rsp_import_export/key} variables. On import, the user is prompted to provide local paths via folder/file pickers, and a new server is created with the resolved attributes.